### PR TITLE
Cz patch pipeline fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 README.md merge=ours
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -242,7 +242,7 @@
 	branch = master
 [submodule "plugins/MQ2ShellCmd"]
 	path = plugins/MQ2ShellCmd
-	url = https://gitlab.com/Knightly1/MQ2ShellCmd.git
+	url = https://github.com/Krakty/MQ2ShellCmd.git
 	branch = master
 [submodule "plugins/MQ2SpawnMaster"]
 	path = plugins/MQ2SpawnMaster
@@ -258,7 +258,7 @@
 	branch = master
 [submodule "plugins/MQ2SQLite"]
 	path = plugins/MQ2SQLite
-	url = https://gitlab.com/Knightly1/MQ2SQLite.git
+	url = https://github.com/Krakty/MQ2SQLite.git
 	branch = master
 [submodule "plugins/MQ2Status"]
 	path = plugins/MQ2Status
@@ -302,7 +302,7 @@
 	branch = master
 [submodule "plugins/MQMountClassicModels"]
 	path = plugins/MQMountClassicModels
-	url = https://github.com/Knightly1/MQMountClassicModels.git
+	url = https://github.com/Krakty/MQMountClassicModels.git
 	branch = main
 [submodule "plugins/MQ2Tracking"]
 	path = plugins/MQ2Tracking
@@ -310,7 +310,7 @@
 	branch = master
 [submodule "plugins/MQTextToSpeech"]
 	path = plugins/MQTextToSpeech
-	url = https://github.com/Knightly1/MQTextToSpeech.git
+	url = https://github.com/Krakty/MQTextToSpeech.git
 	branch = main
 [submodule "plugins/MQ2MeshManager"]
 	path = plugins/MQ2MeshManager

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/eqlib"]
 	path = src/eqlib
-    url = https://github.com/macroquest/eqlib.git
+    url = https://github.com/Krakty/eqlib.git
 [submodule "contrib/vcpkg"]
 	path = contrib/vcpkg
 	url = https://github.com/macroquest/vcpkg.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,11 +3,11 @@
     url = https://github.com/Krakty/eqlib.git
 [submodule "contrib/vcpkg"]
 	path = contrib/vcpkg
-	url = https://github.com/macroquest/vcpkg.git
+	url = https://github.com/Krakty/vcpkg.git
 	branch = macroquest
 [submodule "data/lua/IntegrationTests"]
 	path = src/plugins/lua/lua/IntegrationTests
-	url = https://github.com/macroquest/integration-tests.git
+	url = https://github.com/Krakty/integration-tests.git
 [submodule "plugins/MQ2AASpend"]
 	path = plugins/MQ2AASpend
 	url = https://github.com/RedGuides/MQ2AASpend.git
@@ -62,7 +62,7 @@
 	branch = master
 [submodule "plugins/MQ2Camera"]
 	path = plugins/MQ2Camera
-	url = https://github.com/brainiac/MQ2Camera.git
+	url = https://github.com/Krakty/MQ2Camera.git
 	branch = master
 [submodule "plugins/MQ2Cast"]
 	path = plugins/MQ2Cast
@@ -98,7 +98,7 @@
 	branch = master
 [submodule "plugins/MQ2EasyFind"]
 	path = plugins/MQ2EasyFind
-	url = https://github.com/brainiac/MQ2EasyFind.git
+	url = https://github.com/Krakty/MQ2EasyFind.git
 	branch = master
 [submodule "plugins/MQ2EQBC"]
 	path = plugins/MQ2EQBC
@@ -174,7 +174,7 @@
 	branch = master
 [submodule "plugins/MQ2Nav"]
 	path = plugins/MQ2Nav
-	url = https://github.com/brainiac/MQ2Nav.git
+	url = https://github.com/Krakty/MQ2Nav.git
 	branch = master
 [submodule "plugins/MQ2NetBots"]
 	path = plugins/MQ2NetBots

--- a/tools/re_pipeline/.gitignore
+++ b/tools/re_pipeline/.gitignore
@@ -1,0 +1,37 @@
+# Database files
+*.db
+*.db-wal
+*.db-shm
+
+# Disassembly caches
+disasm_cache/
+unlisted_disasm_cache/
+full_scan_cache/
+
+# Pipeline run output
+pipeline_runs/
+batch_bindiff_logs/
+
+# Python bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Binary files (should not be in repo)
+*.exe
+*.dll
+*.BinExport
+*.BinDiff
+
+# Ghidra project files
+*.gpr
+*.rep/
+
+# Editor/OS files
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Scan result data files (large, regenerable)
+*_scan_results.txt

--- a/tools/re_pipeline/.gitignore
+++ b/tools/re_pipeline/.gitignore
@@ -1,5 +1,4 @@
-# Database files
-*.db
+# Database temp files (the .db itself is tracked in data/)
 *.db-wal
 *.db-shm
 

--- a/tools/re_pipeline/README.md
+++ b/tools/re_pipeline/README.md
@@ -36,6 +36,17 @@ batch_bindiff.sh               Run BinDiff on all consecutive build pairs
 distributed_scan_sequential.sh Distribute rizin scans across multiple hosts
 ```
 
+## Reference Hardware
+
+Timing numbers in this document were measured on:
+
+- **CPU**: 2x Intel Xeon Gold 6240 @ 2.60GHz (72 threads total)
+- **RAM**: 754 GB DDR4
+- **Storage**: NVMe SSD
+- **OS**: Arch Linux
+
+Ghidra analysis and BinDiff are memory-hungry. Expect longer runtimes with less than 32 GB RAM or fewer than 8 cores. The distributed scanning scripts can offload rizin work to additional hosts if available.
+
 ## Prerequisites
 
 - **Ghidra 12.x** with BinExport extension installed at `/opt/ghidra/`

--- a/tools/re_pipeline/README.md
+++ b/tools/re_pipeline/README.md
@@ -1,0 +1,292 @@
+# EQ Reverse Engineering Pipeline
+
+Tools for automating EverQuest struct offset updates on patch day. When Daybreak patches EQ, all struct member offsets shuffle (MSVC struct randomization) and all function addresses change. This pipeline uses BinDiff to map old addresses to new ones, then uses disassembly analysis to identify which struct fields live at which offsets in each build.
+
+The core idea: track accessor functions (getters/setters) that touch a single struct offset. Those functions are stable identifiers for a field across builds, even when the offset itself moves. BinDiff maps the function from old binary to new binary, then you read what offset the new version accesses.
+
+## Architecture
+
+```
+patch_day_pipeline.sh          Main entry point for patch day
+  |
+  +-- Ghidra headless analysis (parallel, 2 binaries)
+  |     +-- ghidra/ExportViaReflection.java   BinExport output
+  |     +-- ghidra/ExtractReferences.java     Cross-reference extraction
+  |
+  +-- BinDiff (old.BinExport vs new.BinExport)
+  |
+  +-- eqgame_h_generator.py    Three-layer address translator
+  |     Layer 1: BinDiff direct match (function-start entries)
+  |     Layer 2: Xref following (data refs inside matched functions)
+  |     Layer 3: Sub-function signature matching (zero-xref entries)
+  |
+  +-- Output: new eqgame.h with translated addresses
+
+eq_xref_db.py                  Persistent SQLite database API
+  |                             Tracks members, offsets, evidence across builds
+  |
+  +-- disasm_accessor_scanner.py   rizin-based accessor identification
+  +-- gap_analysis.py              Size/alignment constraint solving
+  +-- scan_unlisted_all_builds.py  Find accessors outside eqgame.h
+  +-- wide_scan_sequential.py      Full-binary accessor sweep
+  +-- populate_xref_db.py          Historical data backfill
+  +-- extract_2024_headers.py      Pull old eqgame.h from eqlib git
+
+batch_bindiff.sh               Run BinDiff on all consecutive build pairs
+distributed_scan_sequential.sh Distribute rizin scans across multiple hosts
+```
+
+## Prerequisites
+
+- **Ghidra 12.x** with BinExport extension installed at `/opt/ghidra/`
+- **BinDiff 8** (`bindiff` in PATH)
+- **rizin** with rz-ghidra plugin (for disassembly scanning)
+- **Python 3.10+** (stdlib only, no pip packages needed)
+- **JDK 21** (for Ghidra headless analysis)
+- **EQ build archive** at `../../eq-builds/live/` with subdirs like `2025-03-18/` containing `eqgame.exe` and `eqgame.h`
+
+## Quick Start: Patch Day
+
+When a new EQ patch drops:
+
+```bash
+# 1. Run the full pipeline (Ghidra analysis + BinDiff + address translation)
+./patch_day_pipeline.sh \
+    --old-binary /path/to/old/eqgame.exe \
+    --new-binary /path/to/new/eqgame.exe \
+    --old-header /path/to/old/eqgame.h \
+    --answer-key /path/to/new/eqgame.h   # optional, for scoring only
+
+# 2. Output lands in /tmp/patch_day_TIMESTAMP/eqgame_new.h
+```
+
+The pipeline takes about 45 minutes total: ~20 min for Ghidra analysis (two binaries in parallel), ~5 min for BinDiff, ~20 min for address translation with sub-function matching.
+
+## Script Reference
+
+### patch_day_pipeline.sh
+
+The main pipeline. Runs Ghidra headless analysis on both binaries (parallel), runs BinDiff, extracts cross-references, then translates all eqgame.h addresses.
+
+```bash
+./patch_day_pipeline.sh \
+    --old-binary OLD_EXE \
+    --new-binary NEW_EXE \
+    --old-header OLD_EQGAME_H \
+    [--answer-key NEW_EQGAME_H]     # validation only, not used for placement
+    [--work-dir /tmp/patch_day]      # default: /tmp/patch_day_TIMESTAMP
+    [--workers 60]                   # parallel workers for sub-function matching
+    [--ghidra-heap 16G]              # JVM heap for Ghidra
+    [--ghidra-dir /opt/ghidra]       # Ghidra installation path
+```
+
+Steps:
+1. Ghidra headless analysis + BinExport on both binaries (parallel)
+2. BinDiff function matching
+3. Cross-reference extraction from old binary
+4. Three-layer address translation via `eqgame_h_generator.py`
+
+### eq_xref_db.py
+
+SQLite database API for tracking struct members across builds. All other Python scripts import from this. The database stores:
+
+- **binaries** - Build dates, paths, server (live/test)
+- **struct_members** - Field catalog (class, name, type, size)
+- **member_offsets** - Where each field sits in each build (offset + confidence)
+- **function_identities** - Named functions and their addresses per build
+- **evidence_records** - Which functions access which fields (setter/getter/access)
+- **bindiff_matches** - Function address mappings between build pairs
+
+```python
+from eq_xref_db import EQXrefDB
+
+db = EQXrefDB()                              # opens/creates default DB
+db = EQXrefDB('/path/to/custom.db')          # custom path
+
+bid = db.add_binary('2025-03-18', '/path/to/eqgame.exe', '/path/to/eqgame.h')
+db.ingest_eqgame_h(bid, '/path/to/eqgame.h')
+db.ingest_struct_header(bid, '/path/to/CXWnd.h', 'CXWnd')
+
+offset = db.get_offset(bid, 'CXWnd', 'pController')   # returns int or None
+history = db.get_member_history('CXWnd', 'pController') # all builds
+
+# CLI: print database stats
+python3 eq_xref_db.py stats
+```
+
+Confidence levels: `GROUND_TRUTH` (from headers), `HIGH` (single-offset accessor), `MED` (multi-offset function), `LOW` (complex function access).
+
+### disasm_accessor_scanner.py
+
+Scans functions using rizin disassembly to find struct member accesses. For each function in eqgame.h, disassembles it and finds all `[this + offset]` patterns. Functions that only touch one offset are HIGH confidence identifiers for that field.
+
+```bash
+# Scan a single binary
+python3 disasm_accessor_scanner.py \
+    --binary /path/to/eqgame.exe \
+    --offsets /path/to/eqgame.h \
+    --struct-range 0x030:0x268
+
+# Scan a registered build (reads paths from DB)
+python3 disasm_accessor_scanner.py --build 2025-03-18
+
+# Scan all registered builds
+python3 disasm_accessor_scanner.py --all
+
+# Dry run (no DB writes)
+python3 disasm_accessor_scanner.py --all --no-db
+```
+
+Options:
+- `--workers N` - Parallel rizin processes (default: 32)
+- `--struct-range LO:HI` - Hex offset range to scan (default: CXWnd 0x030:0x268)
+
+### gap_analysis.py
+
+Places struct fields that don't have accessor evidence by using size and alignment constraints. If a field is the only one that fits in a gap between two already-identified fields (due to its size/alignment), it gets placed automatically.
+
+Also runs cascade resolution: if a field is identified in build A and there's a BinDiff link to build B, the identifying function's address gets translated and the field gets propagated.
+
+```bash
+python3 gap_analysis.py
+```
+
+No arguments. Runs on all builds in the database, then cascades iteratively until no more fields can be placed.
+
+### batch_bindiff.sh
+
+Runs BinDiff on all consecutive build pairs. Processes 2 pairs concurrently (each pair takes ~25 min). Results are auto-ingested into the xref database.
+
+```bash
+./batch_bindiff.sh
+```
+
+Edit the `PAIRS` array at the top of the script to add new build pairs. Each pair is `"OLD_DATE:NEW_DATE"`. Already-completed pairs are skipped.
+
+Expects build files at `../../eq-builds/live/DATE/eqgame.exe` and `.../eqgame.h`.
+
+### distributed_scan_sequential.sh
+
+Distributes rizin disassembly scanning across multiple hosts (default: pvehost1-4). Copies binaries to each host, runs scans with 48 workers per host, then you collect results back.
+
+```bash
+./distributed_scan_sequential.sh
+```
+
+Edit `HOSTS` and `BUILDS_DIR` at the top. After completion, collect results:
+
+```bash
+for h in pvehost{1..4}; do
+    for d in $(ssh $h 'ls -d /tmp/eq_scan/20*/disasm 2>/dev/null'); do
+        date=$(basename $(dirname $d))
+        mkdir -p data/disasm_cache/$date
+        rsync -a $h:$d/ data/disasm_cache/$date/
+    done
+done
+```
+
+### extract_2024_headers.py
+
+Extracts historical eqgame.h files from eqlib git history by matching `__ClientDate` values to build dates. Also extracts CXWnd.h when available. Registers everything in the xref database.
+
+```bash
+python3 extract_2024_headers.py
+```
+
+Expects:
+- eqlib git repo at `../../eqlib-history/` with a `live` branch
+- Build directories at `../../eq-builds/live/2024-*/`
+
+### populate_xref_db.py
+
+Backfills the cross-reference database from all available historical data:
+
+1. Registers all live/test builds
+2. Ingests eqgame.h function addresses
+3. Ingests CXWnd member offsets from eqlib git commits
+4. Imports BinDiff results from pipeline run directories
+
+```bash
+python3 populate_xref_db.py
+```
+
+Edit `EQLIB_COMMITS` dict to map build dates to eqlib git commits that have CXWnd.h for that patch.
+
+### scan_unlisted_all_builds.py
+
+Finds CXWnd accessor functions that are NOT in eqgame.h. These are functions in the CXWnd code range (0x1405B0000-0x14060FFFF) that BinDiff knows about but eqgame.h doesn't list. If an unlisted function is a pure accessor (touches only one CXWnd-range offset), and it shows up consistently across 5+ builds, it gets added as HIGH evidence.
+
+```bash
+python3 scan_unlisted_all_builds.py
+```
+
+Uses 48 parallel workers per build. Caches results in `../../data/unlisted_disasm_cache/`.
+
+### wide_scan_sequential.py
+
+Like `scan_unlisted_all_builds.py` but scans the entire binary (not just CXWnd code range) for any function that accesses remaining unidentified CXWnd fields. Used as a last resort to fill gaps that the other scanners miss.
+
+```bash
+python3 wide_scan_sequential.py
+```
+
+Targets only fields that don't already have HIGH confidence evidence in 5+ builds.
+
+## Database Schema
+
+The `eq_xref_db.py` module manages a SQLite database with these tables:
+
+| Table | Purpose |
+|-------|---------|
+| `binaries` | One row per EQ build. Keyed by build_date. Stores paths, server type, image base. |
+| `struct_members` | Field catalog. Unique on (class_name, field_name). Stores type and size. |
+| `member_offsets` | Where each field sits in each build. Confidence: GROUND_TRUTH/HIGH/MED/LOW. |
+| `function_identities` | Named functions per build. Address changes each patch. |
+| `evidence_records` | Links functions to fields they access. Type: setter/getter/ini_key/destructor/xref/access. |
+| `bindiff_matches` | Old->new function address pairs from BinDiff, with similarity scores. |
+
+Key relationships:
+- `member_offsets` references both `binaries` and `struct_members`
+- `evidence_records` references `binaries`, `struct_members`, and `function_identities`
+- `bindiff_matches` references `binaries` (old and new)
+
+## Supporting Scripts
+
+These are used internally or for specific analysis tasks:
+
+- `eqgame_h_generator.py` - Three-layer address translator called by the main pipeline
+- `xref_translator.py` - Xref-following address translator (alternative approach)
+- `auto_field_mapper.py` - Automated field mapping using vtable decompilation
+- `vtable_accessor_scanner.py` - Parse Ghidra decompilation output for accessor patterns
+- `parse_vtable_decompilations.py` - Batch parse vtable decompilation dumps
+- `walk_vtable.py` - Walk CXWnd vtable entries and classify them
+- `scan_full_binary.py` - Full binary scan variant
+- `scan_unlisted_accessors.py` - Single-build unlisted accessor scanner
+- `populate_evidence.py` - Populate evidence records from decompilation data
+
+### Ghidra Scripts (ghidra/)
+
+- `ExportViaReflection.java` - BinExport via reflection (works around Ghidra extension API quirks)
+- `ExtractReferences.java` - Extract code/data cross-references for target addresses
+- `ExtractXrefs.java` - Simpler xref extraction variant
+
+## Data Layout
+
+The pipeline expects this directory structure relative to the repo root:
+
+```
+../../eq-builds/live/
+    2025-03-18/
+        eqgame.exe
+        eqgame.h
+        CXWnd.h          (optional)
+    2025-04-15/
+        ...
+../../data/
+    eq_xref.db            Cross-reference database
+    disasm_cache/          Cached rizin disassembly per build
+    pipeline_runs/         BinDiff pipeline output per pair
+    unlisted_disasm_cache/ Cache for unlisted function scans
+    full_scan_cache/       Cache for wide binary scans
+    batch_bindiff_logs/    Logs from batch processing
+```

--- a/tools/re_pipeline/README.md
+++ b/tools/re_pipeline/README.md
@@ -9,9 +9,10 @@ The core idea: track accessor functions (getters/setters) that touch a single st
 ```
 patch_day_pipeline.sh          Main entry point for patch day
   |
-  +-- Ghidra headless analysis (parallel, 2 binaries)
-  |     +-- ghidra/ExportViaReflection.java   BinExport output
-  |     +-- ghidra/ExtractReferences.java     Cross-reference extraction
+  +-- Ghidra headless (parallel, 2 binaries)
+  |     +-- Old binary: ExportViaReflection.java (BinExport) then ExtractReferences.java
+  |     |              in one JVM (no second project open)
+  |     +-- New binary: BinExport only
   |
   +-- BinDiff (old.BinExport vs new.BinExport)
   |
@@ -73,11 +74,18 @@ When a new EQ patch drops:
 
 The pipeline takes about 45 minutes total: ~20 min for Ghidra analysis (two binaries in parallel), ~5 min for BinDiff, ~20 min for address translation with sub-function matching.
 
+### Patch day troubleshooting
+
+- **Do not `kill -9` Ghidra** while Step 1 is running; orphaned JVMs can leave inconsistent project state. **Do not** use zero-byte **`*.gpr`** as a health signal — Ghidra often keeps `.gpr` minimal while storing data under **`*.rep`**; the pipeline validates **BinExport** + **`old_xrefs.json`** instead.
+- **Work directory**: Default is under `/tmp`. If your environment evicts `/tmp` or you need a persistent path, pass **`--work-dir`** to a directory on a normal local filesystem.
+- **Logs**: Both Ghidra runs write only to **`old_ghidra.log`** and **`new_ghidra.log`** under the work dir (no live `tee` to the terminal, so **`wait`** reflects the real **`analyzeHeadless`** exit code). On failure, the script prints the last lines of the relevant log.
+- **Last resort**: If Ghidra still misbehaves with project ownership, ensure `java -XshowSettings:properties` reports sensible `user.name` / `user.home`; exotic environments can set `JAVA_TOOL_OPTIONS=-Duser.name=... -Duser.home=...` before running the pipeline.
+
 ## Script Reference
 
 ### patch_day_pipeline.sh
 
-The main pipeline. Runs Ghidra headless analysis on both binaries (parallel), runs BinDiff, extracts cross-references, then translates all eqgame.h addresses.
+The main pipeline. Runs Ghidra headless on both binaries in parallel (old: BinExport + xref extraction in one session; new: BinExport only), runs BinDiff, then translates all `eqgame.h` addresses with `eqgame_h_generator.py`.
 
 ```bash
 ./patch_day_pipeline.sh \
@@ -92,10 +100,9 @@ The main pipeline. Runs Ghidra headless analysis on both binaries (parallel), ru
 ```
 
 Steps:
-1. Ghidra headless analysis + BinExport on both binaries (parallel)
+1. Ghidra headless: **old** binary — BinExport then `ExtractReferences` (same JVM); **new** binary — BinExport only (parallel)
 2. BinDiff function matching
-3. Cross-reference extraction from old binary
-4. Three-layer address translation via `eqgame_h_generator.py`
+3. Three-layer address translation via `eqgame_h_generator.py` (uses `old_xrefs.json` from step 1)
 
 ### eq_xref_db.py
 
@@ -278,6 +285,7 @@ These are used internally or for specific analysis tasks:
 ### Ghidra Scripts (ghidra/)
 
 - `ExportViaReflection.java` - BinExport via reflection (works around Ghidra extension API quirks)
+- `ReferenceManagerUtil.java` - Shared helper: calls `ReferenceManager.getReferencesTo` via reflection so xref scripts work across Ghidra versions (return type differs by release)
 - `ExtractReferences.java` - Extract code/data cross-references for target addresses
 - `ExtractXrefs.java` - Simpler xref extraction variant
 

--- a/tools/re_pipeline/auto_field_mapper.py
+++ b/tools/re_pipeline/auto_field_mapper.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""
+Automated Field Mapper for EQ struct reverse engineering.
+
+Usage:
+    python3 auto_field_mapper.py --class CXWnd --binary /path/to/eqgame.exe --offsets /path/to/eqgame.h
+
+Does:
+1. Parses eqgame.h for function addresses
+2. Parallel decompiles via rz-ghidra
+3. Extracts field offsets from setter/getter patterns
+4. Matches INI string keys to offsets
+5. Applies type elimination for unique types
+6. Reports: named fields, unnamed offsets needing manual review
+
+Does NOT:
+- Behavioral naming (requires human/AI reading of function logic)
+- Binary diffing across versions (separate tool)
+"""
+
+import re
+import os
+import sys
+import json
+import subprocess
+import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+# Import our accessor scanner
+sys.path.insert(0, os.path.dirname(__file__))
+from vtable_accessor_scanner import parse_decompilation
+
+
+def parse_offsets_file(offsets_path, class_prefix):
+    """Parse eqgame.h for function addresses matching a class prefix."""
+    functions = {}
+    pattern = re.compile(
+        rf'#define\s+({class_prefix}__(\w+))_x\s+(0x[0-9a-fA-F]+)'
+    )
+    with open(offsets_path) as f:
+        for line in f:
+            m = pattern.match(line.strip())
+            if m:
+                full_name = m.group(1)
+                func_name = m.group(2)
+                addr = m.group(3)
+                functions[func_name] = addr
+    return functions
+
+
+def decompile_function(binary_path, addr, func_name):
+    """Decompile a single function via rz-ghidra. Returns (name, code)."""
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"af @ {addr}; pdg @ {addr}",
+             binary_path],
+            capture_output=True, text=True, timeout=30
+        )
+        code = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        return (func_name, addr, code)
+    except (subprocess.TimeoutExpired, Exception) as e:
+        return (func_name, addr, f"// ERROR: {e}")
+
+
+def parallel_decompile(binary_path, functions, max_workers=32):
+    """Decompile all functions in parallel."""
+    results = {}
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(decompile_function, binary_path, addr, name): name
+            for name, addr in functions.items()
+        }
+        for future in as_completed(futures):
+            name, addr, code = future.result()
+            if code and len(code) > 20 and "ERROR" not in code:
+                results[name] = code
+                print(f"  Decompiled {name} ({len(code.split(chr(10)))} lines)")
+            else:
+                print(f"  FAILED {name}")
+    return results
+
+
+def extract_setter_names(decompilations):
+    """Extract field names from SetX functions that write param2 to exactly 1 offset."""
+    named = {}
+    for func_name, code in decompilations.items():
+        findings = parse_decompilation(code, func_name)
+        setters = [f for f in findings if f["type"] == "setter"]
+        getters = [f for f in findings if f["type"] == "getter"]
+
+        if func_name.startswith("Set") and len(setters) == 1:
+            off = setters[0]["offset"]
+            field_name = func_name[3:]  # Strip "Set"
+            named[off] = (field_name, f"setter in {func_name}", "HIGH")
+
+        elif func_name.startswith("Get") and len(getters) == 1:
+            off = getters[0]["offset"]
+            field_name = func_name[3:]  # Strip "Get"
+            named[off] = (field_name, f"getter in {func_name}", "HIGH")
+
+    return named
+
+
+def extract_ini_keys(decompilations):
+    """Extract field names from INI load/store functions using string keys."""
+    named = {}
+    ini_funcs = {k: v for k, v in decompilations.items()
+                 if "LoadIni" in k or "StoreIni" in k}
+
+    offset_pat = re.compile(
+        r'(?:arg1|param_1)\s*\+\s*(?:0x)?([0-9a-fA-F]+)',
+        re.IGNORECASE
+    )
+
+    for func_name, code in ini_funcs.items():
+        lines = code.split('\n')
+        for i, line in enumerate(lines):
+            strings = re.findall(r'"([A-Za-z]+)"', line)
+            offsets = []
+            for m in offset_pat.finditer(line):
+                offsets.append(int(m.group(1), 16))
+
+            if strings and offsets:
+                for s in strings:
+                    for off in offsets:
+                        if off not in named:
+                            # Map common INI key names to field names
+                            key_to_field = {
+                                "ClickThrough": "bClickThroughMenuItemStatus",
+                                "Border": "bShowBorder",
+                                "Escapable": "bEscapable",
+                                "Fades": "Fades",
+                                "Alpha": "Alpha",
+                                "FadeToAlpha": "FadeToAlpha",
+                                "Duration": "FadeDuration",
+                                "Delay": "FadeDelay",
+                                "BGType": "BGType",
+                            }
+                            field = key_to_field.get(s, s)
+                            named[off] = (field, f"INI key '{s}' in {func_name}", "HIGH")
+
+    return named
+
+
+def extract_all_offsets(decompilations, offset_range):
+    """Extract all accessed offsets from all functions."""
+    lo, hi = offset_range
+    offset_pat = re.compile(
+        r'(?:arg1|param_1)\s*\+\s*(?:0x)?([0-9a-fA-F]+)',
+        re.IGNORECASE
+    )
+
+    all_offsets = {}  # offset -> [(func, line)]
+    for func_name, code in decompilations.items():
+        for line in code.split('\n'):
+            for m in offset_pat.finditer(line):
+                off = int(m.group(1), 16)
+                if lo <= off < hi:
+                    if off not in all_offsets:
+                        all_offsets[off] = []
+                    all_offsets[off].append((func_name, line.strip()[:100]))
+
+    return all_offsets
+
+
+def apply_type_elimination(known_fields, all_field_names_types):
+    """For fields with unique types, place them by elimination."""
+    named = {}
+
+    # Group unplaced fields by type
+    placed_offsets = set(known_fields.keys())
+    unplaced = {off: (name, typ) for off, (name, typ) in all_field_names_types.items()
+                if off not in placed_offsets}
+
+    type_groups = {}
+    for off, (name, typ) in unplaced.items():
+        if typ not in type_groups:
+            type_groups[typ] = []
+        type_groups[typ].append((off, name))
+
+    for typ, fields in type_groups.items():
+        if len(fields) == 1:
+            off, name = fields[0]
+            named[off] = (name, f"unique type {typ}", "ELIMINATION")
+
+    return named
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Automated Field Mapper")
+    parser.add_argument("--binary", required=True, help="Path to eqgame.exe")
+    parser.add_argument("--offsets", required=True, help="Path to eqgame.h offsets file")
+    parser.add_argument("--class", dest="classname", required=True,
+                        help="Class name prefix (CXWnd, PlayerZoneClient, ItemBase)")
+    parser.add_argument("--header", help="Path to header with field layout for type info")
+    parser.add_argument("--workers", type=int, default=32, help="Parallel workers")
+    parser.add_argument("--cache-dir", default="/tmp/field_mapper_cache",
+                        help="Cache directory for decompilations")
+    parser.add_argument("--answer-key", help="Path to brainiac's header for scoring (validation only)")
+    args = parser.parse_args()
+
+    cache_dir = Path(args.cache_dir) / args.classname
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # Step 1: Parse function addresses
+    print(f"\n=== Step 1: Parse function addresses for {args.classname} ===")
+    # Try multiple prefixes
+    prefixes = [args.classname]
+    if args.classname == "CXWnd":
+        prefixes.extend(["CSidlScreenWnd", "CXWndManager"])
+    elif args.classname == "PlayerZoneClient":
+        prefixes.extend(["PlayerClient", "PlayerBase"])
+
+    all_functions = {}
+    for prefix in prefixes:
+        funcs = parse_offsets_file(args.offsets, prefix)
+        all_functions.update(funcs)
+        print(f"  {prefix}: {len(funcs)} functions")
+
+    print(f"  Total: {len(all_functions)} functions")
+
+    # Step 2: Parallel decompile
+    print(f"\n=== Step 2: Parallel decompile ({args.workers} workers) ===")
+    decompilations = parallel_decompile(args.binary, all_functions, args.workers)
+    print(f"  Successfully decompiled: {len(decompilations)}/{len(all_functions)}")
+
+    # Cache decompilations
+    for name, code in decompilations.items():
+        (cache_dir / f"{name}.txt").write_text(code)
+
+    # Step 3: Extract setter/getter names
+    print(f"\n=== Step 3: Extract accessor names ===")
+    accessor_names = extract_setter_names(decompilations)
+    for off, (name, evidence, conf) in sorted(accessor_names.items()):
+        print(f"  0x{off:03X} = {name} [{conf}] ({evidence})")
+
+    # Step 4: Extract INI string keys
+    print(f"\n=== Step 4: Extract INI string keys ===")
+    ini_names = extract_ini_keys(decompilations)
+    for off, (name, evidence, conf) in sorted(ini_names.items()):
+        print(f"  0x{off:03X} = {name} [{conf}] ({evidence})")
+
+    # Step 5: Extract all accessed offsets
+    print(f"\n=== Step 5: Extract all accessed offsets ===")
+    # Guess offset range from class
+    ranges = {
+        "CXWnd": (0x030, 0x268),
+        "PlayerZoneClient": (0x1CC, 0x650),
+        "ItemBase": (0x008, 0x114),
+    }
+    offset_range = ranges.get(args.classname, (0x008, 0x800))
+    all_offsets = extract_all_offsets(decompilations, offset_range)
+    print(f"  Unique offsets accessed: {len(all_offsets)}")
+
+    # Combine all named fields
+    named = {}
+    named.update({off: (n, e, c) for off, (n, e, c) in accessor_names.items()})
+    for off, (n, e, c) in ini_names.items():
+        if off not in named:
+            named[off] = (n, e, c)
+
+    # Step 6: Report
+    print(f"\n{'='*60}")
+    print(f"RESULTS: {args.classname}")
+    print(f"{'='*60}")
+    print(f"Automatically named: {len(named)}")
+    print(f"Offsets detected: {len(all_offsets)}")
+    print(f"Unnamed (need manual behavioral analysis): {len(all_offsets) - len(named)}")
+
+    print(f"\n=== NAMED FIELDS ===")
+    for off in sorted(named.keys()):
+        name, evidence, conf = named[off]
+        print(f"  0x{off:03X} = {name:30s} [{conf}]")
+
+    print(f"\n=== UNNAMED OFFSETS (need manual review) ===")
+    for off in sorted(all_offsets.keys()):
+        if off not in named:
+            funcs = sorted(set(f for f, _ in all_offsets[off]))[:3]
+            print(f"  0x{off:03X}: accessed by {', '.join(funcs)}")
+
+    # Step 7: Score against answer key if provided
+    if args.answer_key:
+        print(f"\n=== SCORING AGAINST ANSWER KEY ===")
+        brainiac = {}
+        in_block = False
+        marker = f"@start: {args.classname} Members"
+        end_marker = f"@end: {args.classname} Members"
+        # Handle different marker formats
+        with open(args.answer_key) as f:
+            for line in f:
+                if marker in line or "@start:" in line:
+                    if args.classname.lower() in line.lower():
+                        in_block = True
+                        continue
+                if end_marker in line or ("@end:" in line and in_block):
+                    break
+                if in_block and line.strip().startswith("/*0x"):
+                    m = re.match(r'\s*/\*0x([0-9a-fA-F]+)\*/\s+\S+\s+(\w+)', line)
+                    if m:
+                        brainiac[int(m.group(1), 16)] = m.group(2)
+
+        if brainiac:
+            def fuzzy(a, b):
+                return a.lower().lstrip('p').lstrip('b') == b.lower().lstrip('p').lstrip('b')
+
+            correct = wrong = 0
+            for off, (name, _, _) in named.items():
+                brain = brainiac.get(off, "???")
+                if brain == "???" or brain in ("int","bool","unsigned"):
+                    continue
+                if fuzzy(name, brain):
+                    correct += 1
+                else:
+                    wrong += 1
+                    print(f"  WRONG: 0x{off:03X} ours={name} brain={brain}")
+
+            detected = len(set(all_offsets.keys()) & set(brainiac.keys()))
+            print(f"\n  Offset detection: {detected}/{len(brainiac)} ({100*detected//len(brainiac)}%)")
+            print(f"  Auto-named correct: {correct}, wrong: {wrong}")
+            print(f"  Accuracy: {100*correct//(correct+wrong) if correct+wrong else 0}%")
+
+    # Save results
+    output = {
+        "class": args.classname,
+        "named": {f"0x{off:03X}": {"name": n, "evidence": e, "confidence": c}
+                  for off, (n, e, c) in named.items()},
+        "unnamed_offsets": [f"0x{off:03X}" for off in sorted(all_offsets.keys()) if off not in named],
+        "total_offsets": len(all_offsets),
+    }
+    output_path = cache_dir / "results.json"
+    with open(output_path, 'w') as f:
+        json.dump(output, f, indent=2)
+    print(f"\nResults saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/re_pipeline/batch_bindiff.sh
+++ b/tools/re_pipeline/batch_bindiff.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# batch_bindiff.sh - Queue and run all needed BinDiff pairs
+#
+# Runs pairs 2 at a time. Each takes ~25 min.
+# Results auto-ingested into the DB.
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILDS_DIR="$BASE_DIR/eq-builds/live"
+PIPELINE="$SCRIPT_DIR/patch_day_pipeline.sh"
+PIPELINE_RUNS="$BASE_DIR/data/pipeline_runs"
+LOG_DIR="$BASE_DIR/data/batch_bindiff_logs"
+
+mkdir -p "$LOG_DIR"
+
+run_pair() {
+    local old_date="$1"
+    local new_date="$2"
+    local work_dir="$PIPELINE_RUNS/patch_day_${old_date}_to_${new_date}"
+
+    if [ -f "$work_dir/output/old_vs_new.BinDiff" ]; then
+        echo "[SKIP] $old_date → $new_date (already complete)"
+        return 0
+    fi
+
+    local old_exe="$BUILDS_DIR/$old_date/eqgame.exe"
+    local new_exe="$BUILDS_DIR/$new_date/eqgame.exe"
+    local old_h="$BUILDS_DIR/$old_date/eqgame.h"
+
+    if [ ! -f "$old_exe" ] || [ ! -f "$new_exe" ] || [ ! -f "$old_h" ]; then
+        echo "[ERROR] Missing files for $old_date → $new_date"
+        return 1
+    fi
+
+    local answer_args=""
+    local new_h="$BUILDS_DIR/$new_date/eqgame.h"
+    if [ -f "$new_h" ]; then
+        answer_args="--answer-key $new_h"
+    fi
+
+    echo "[START] $old_date → $new_date ($(date '+%H:%M:%S'))"
+
+    if bash "$PIPELINE" \
+        --old-binary "$old_exe" \
+        --new-binary "$new_exe" \
+        --old-header "$old_h" \
+        --work-dir "$work_dir" \
+        $answer_args \
+        > "$LOG_DIR/${old_date}_to_${new_date}.log" 2>&1; then
+
+        echo "[DONE] $old_date → $new_date ($(date '+%H:%M:%S'))"
+        python3 -c "
+from tools.re_pipeline.eq_xref_db import EQXrefDB
+db = EQXrefDB()
+old_id = db.get_binary_id('$old_date')
+new_id = db.get_binary_id('$new_date')
+if old_id and new_id:
+    count = db.ingest_bindiff(old_id, new_id, '$work_dir/output/old_vs_new.BinDiff')
+    print(f'  Ingested {count} matches')
+db.close()
+" 2>&1
+    else
+        echo "[FAIL] $old_date → $new_date (see log)"
+    fi
+}
+
+# All pairs to process
+PAIRS=(
+    "2024-01-17:2024-02-01"
+    "2024-02-01:2024-02-20"
+    "2024-02-20:2024-02-21"
+    "2024-02-21:2024-02-22"
+    "2024-02-22:2024-03-29"
+    "2024-03-29:2024-04-01"
+    "2024-04-01:2024-04-02"
+    "2024-04-02:2024-04-16"
+    "2024-04-16:2024-05-14"
+    "2024-05-14:2024-05-22"
+    "2024-05-22:2024-06-18"
+    "2024-06-18:2024-06-24"
+    "2024-06-24:2024-07-16"
+    "2024-07-16:2024-07-18"
+    "2024-07-18:2024-07-22"
+    "2024-07-22:2024-08-15"
+    "2024-08-15:2024-10-15"
+    "2024-10-15:2024-10-16"
+    "2024-10-16:2024-11-08"
+    "2024-11-08:2024-11-19"
+    "2024-11-19:2024-11-30"
+    "2024-11-30:2024-12-03"
+    "2024-12-03:2024-12-05"
+    "2024-12-05:2024-12-10"
+    "2024-12-10:2025-01-14"
+    "2025-03-11:2025-03-18"
+    "2025-03-18:2025-04-15"
+    "2025-04-15:2025-04-17"
+    "2025-04-17:2025-05-20"
+    "2025-05-20:2025-06-17"
+    "2025-06-17:2025-07-15"
+    "2025-07-15:2025-07-18"
+    "2025-07-18:2025-08-19"
+    "2025-08-26:2025-09-03"
+    "2025-09-03:2025-09-07"
+    "2025-09-07:2025-09-16"
+    "2025-10-14:2025-11-12"
+    "2025-11-12:2025-11-13"
+    "2025-11-13:2025-11-17"
+    "2025-11-17:2025-12-01"
+    "2025-12-01:2025-12-04"
+    "2025-12-04:2025-12-08"
+)
+
+echo "=========================================="
+echo "Batch BinDiff: ${#PAIRS[@]} pairs, 2 concurrent"
+echo "=========================================="
+
+# Process pairs 2 at a time
+i=0
+completed=0
+failed=0
+while [ $i -lt ${#PAIRS[@]} ]; do
+    # Launch up to 2 pairs
+    pids=()
+    for j in 0 1; do
+        idx=$((i + j))
+        if [ $idx -ge ${#PAIRS[@]} ]; then break; fi
+
+        pair="${PAIRS[$idx]}"
+        old_date="${pair%%:*}"
+        new_date="${pair##*:}"
+
+        run_pair "$old_date" "$new_date" &
+        pids+=($!)
+    done
+
+    # Wait for this batch of 2
+    for pid in "${pids[@]}"; do
+        if wait "$pid"; then
+            ((completed++))
+        else
+            ((failed++))
+        fi
+    done
+
+    i=$((i + 2))
+    echo "--- Progress: $((completed + failed))/${#PAIRS[@]} done ($completed ok, $failed fail) ---"
+done
+
+echo ""
+echo "=========================================="
+echo "Complete: $completed succeeded, $failed failed"
+echo "=========================================="

--- a/tools/re_pipeline/disasm_accessor_scanner.py
+++ b/tools/re_pipeline/disasm_accessor_scanner.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+disasm_accessor_scanner.py - Extract struct member accesses from disassembly.
+
+Uses rizin disassembly (not decompiler) to find every instruction that
+reads or writes to [this + offset]. This is more reliable than the
+decompiler because there's no pattern-matching ambiguity.
+
+For each function in eqgame.h:
+1. Disassemble with rizin
+2. Find all [reg + offset] patterns where reg holds arg1 (this pointer)
+3. Classify: single-access = HIGH, write-with-arg2 = HIGH, multi = MED
+4. Cross-reference with ground truth to name the offsets
+
+Usage:
+    python3 disasm_accessor_scanner.py --binary /path/to/eqgame.exe \
+        --offsets /path/to/eqgame.h --struct-range 0x030:0x268
+"""
+
+import re
+import os
+import sys
+import subprocess
+import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(__file__))
+from eq_xref_db import EQXrefDB
+
+
+def disassemble_function(binary_path, addr_hex, func_name):
+    """Disassemble a function and return raw text."""
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"af @ {addr_hex}; pdf @ {addr_hex}",
+             binary_path],
+            capture_output=True, text=True, timeout=30
+        )
+        # Strip ANSI codes
+        text = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        return (func_name, addr_hex, text)
+    except Exception:
+        return (func_name, addr_hex, None)
+
+
+def extract_this_offsets(disasm_text, struct_lo=0x030, struct_hi=0x268):
+    """Extract all [this + offset] accesses from disassembly.
+
+    Returns list of (offset, access_type, instruction)
+    where access_type is 'read' or 'write'.
+
+    Tracks register aliases: if rcx (arg1) is moved to rbx/rdi/rsi,
+    accesses via those registers also count.
+    """
+    if not disasm_text:
+        return []
+
+    results = []
+    lines = disasm_text.split('\n')
+
+    # Track which registers hold 'this' (arg1 = rcx on Windows x64)
+    this_regs = {'rcx'}
+
+    # Pattern: mov reg, rcx (or other this_reg) at function start = alias
+    alias_pat = re.compile(r'mov\s+(r\w+),\s*(r\w+)')
+
+    # Pattern: access [reg + offset]
+    access_pat = re.compile(
+        r'(mov|movzx|movsx|lea|cmp|test|add|sub|or|and|xor)\s+'
+        r'([^,]+),\s*'  # destination
+        r'.*?\[(\w+)\s*\+\s*0x([0-9a-fA-F]+)\]'  # [reg + offset]
+    )
+    # Also: write pattern [reg + offset], src
+    write_pat = re.compile(
+        r'(mov|movzx)\s+'
+        r'.*?\[(\w+)\s*\+\s*0x([0-9a-fA-F]+)\]'  # [reg + offset] as dest
+        r',\s*(\w+)'  # source register
+    )
+
+    for line in lines:
+        line = line.strip()
+
+        # Track register aliases (first few instructions usually set up this)
+        am = alias_pat.search(line)
+        if am:
+            dst, src = am.group(1), am.group(2)
+            if src in this_regs:
+                this_regs.add(dst)
+
+        # Check for writes: mov [reg+off], something
+        wm = write_pat.search(line)
+        if wm:
+            reg = wm.group(2)
+            offset = int(wm.group(3), 16)
+            if reg in this_regs and struct_lo <= offset < struct_hi:
+                results.append((offset, 'write', line))
+                continue
+
+        # Check for reads: mov something, [reg+off]
+        rm = access_pat.search(line)
+        if rm:
+            reg = rm.group(3)
+            offset = int(rm.group(4), 16)
+            if reg in this_regs and struct_lo <= offset < struct_hi:
+                results.append((offset, 'read', line))
+
+    return results
+
+
+def classify_function(func_name, accesses):
+    """Classify a function's relationship to struct offsets.
+
+    Returns list of (offset, confidence, evidence_type, detail)
+    """
+    if not accesses:
+        return []
+
+    # Unique offsets accessed
+    offsets = defaultdict(lambda: {'reads': [], 'writes': []})
+    for offset, atype, instr in accesses:
+        offsets[offset][atype + 's'].append(instr)
+
+    results = []
+    unique_offsets = set(offsets.keys())
+
+    # Single-offset function: definitive identifier
+    if len(unique_offsets) == 1:
+        off = list(unique_offsets)[0]
+        writes = offsets[off]['writes']
+        reads = offsets[off]['reads']
+        if writes:
+            results.append((off, 'HIGH', 'setter',
+                           f"only offset in {func_name}, writes"))
+        else:
+            results.append((off, 'HIGH', 'getter',
+                           f"only offset in {func_name}, reads"))
+        return results
+
+    # Two-offset function where one is a write: strong setter candidate
+    if len(unique_offsets) == 2:
+        for off in unique_offsets:
+            if offsets[off]['writes']:
+                results.append((off, 'HIGH', 'setter',
+                               f"write target in simple {func_name} (2 offsets)"))
+            else:
+                results.append((off, 'MED', 'access',
+                               f"read in simple {func_name} (2 offsets)"))
+        return results
+
+    # Three-offset function with one write: still decent
+    if len(unique_offsets) <= 4:
+        for off in unique_offsets:
+            if offsets[off]['writes']:
+                results.append((off, 'MED', 'setter',
+                               f"write in {func_name} ({len(unique_offsets)} offsets)"))
+            else:
+                results.append((off, 'MED', 'access',
+                               f"read in {func_name} ({len(unique_offsets)} offsets)"))
+        return results
+
+    # Complex function: all accesses are LOW, but still useful for coverage
+    for off in unique_offsets:
+        results.append((off, 'LOW', 'access',
+                       f"access in complex {func_name} ({len(unique_offsets)} offsets)"))
+
+    return results
+
+
+def scan_binary(binary_path, offsets_path, struct_range, workers=32, cache_dir=None):
+    """Scan all functions in eqgame.h against a binary."""
+
+    struct_lo, struct_hi = struct_range
+
+    # Parse all function addresses from eqgame.h
+    functions = {}
+    with open(offsets_path) as f:
+        for line in f:
+            m = re.match(r'#define\s+(\S+)_x\s+(0x[0-9a-fA-F]+)', line.strip())
+            if m:
+                functions[m.group(1)] = m.group(2)
+
+    print(f"Scanning {len(functions)} functions in {binary_path}")
+
+    # Disassemble all functions (with caching)
+    disasm_results = {}
+
+    if cache_dir:
+        cache_dir = Path(cache_dir)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+    to_disasm = {}
+    for func_name, addr in functions.items():
+        if cache_dir:
+            cache_file = cache_dir / f"{func_name}.asm"
+            if cache_file.exists():
+                disasm_results[func_name] = (func_name, addr, cache_file.read_text())
+                continue
+        to_disasm[func_name] = addr
+
+    if disasm_results:
+        print(f"  {len(disasm_results)} cached, {len(to_disasm)} to disassemble")
+
+    if to_disasm:
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(disassemble_function, binary_path, addr, name): name
+                for name, addr in to_disasm.items()
+            }
+            done = 0
+            for future in as_completed(futures):
+                name, addr, text = future.result()
+                done += 1
+                if text and len(text) > 10:
+                    disasm_results[name] = (name, addr, text)
+                    if cache_dir:
+                        (cache_dir / f"{name}.asm").write_text(text)
+                if done % 50 == 0:
+                    print(f"  Disassembled {done}/{len(to_disasm)}...")
+
+    print(f"  Total disassembled: {len(disasm_results)}")
+
+    # Extract offset accesses from each function
+    all_classifications = []  # (func_name, offset, confidence, evidence_type, detail)
+
+    for func_name, (_, addr, text) in disasm_results.items():
+        accesses = extract_this_offsets(text, struct_lo, struct_hi)
+        classifications = classify_function(func_name, accesses)
+        for offset, confidence, etype, detail in classifications:
+            all_classifications.append((func_name, int(addr, 16), offset, confidence, etype, detail))
+
+    return all_classifications
+
+
+def populate_db(db, binary_id, classifications, struct_class='CXWnd'):
+    """Store scan results in the database."""
+    count = 0
+    for func_name, func_addr, offset, confidence, etype, detail in classifications:
+        # Look up which field is at this offset in this build
+        member = db.get_member_at_offset(binary_id, struct_class, offset)
+        if not member:
+            # Try CSidlScreenWnd
+            member = db.get_member_at_offset(binary_id, 'CSidlScreenWnd', offset)
+            if member:
+                struct_class_actual = 'CSidlScreenWnd'
+            else:
+                continue
+        else:
+            struct_class_actual = struct_class
+
+        field_name = member['field_name']
+
+        db.add_evidence(
+            binary_id=binary_id,
+            class_name=struct_class_actual,
+            field_name=field_name,
+            func_name=func_name,
+            func_addr=func_addr,
+            evidence_type=etype,
+            decompile_line=detail,
+            confidence=confidence
+        )
+        count += 1
+
+    return count
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Disassembly-based accessor scanner")
+    parser.add_argument("--build", help="Specific build date (scans one)")
+    parser.add_argument("--all", action="store_true", help="Scan all builds")
+    parser.add_argument("--binary", help="Path to eqgame.exe (if not using --build)")
+    parser.add_argument("--offsets", help="Path to eqgame.h (if not using --build)")
+    parser.add_argument("--struct-range", default="0x030:0x268",
+                        help="Offset range lo:hi (default CXWnd)")
+    parser.add_argument("--workers", type=int, default=32, help="Parallel workers")
+    parser.add_argument("--no-db", action="store_true", help="Don't write to database")
+    args = parser.parse_args()
+
+    lo, hi = [int(x, 16) for x in args.struct_range.split(':')]
+
+    db = EQXrefDB()
+
+    if args.all:
+        builds = [(r['build_date'], r['binary_path'], r['eqgame_h'])
+                  for r in db.list_binaries() if r['server'] == 'live' and r['eqgame_h']]
+    elif args.build:
+        bid = db.get_binary_id(args.build)
+        row = db.conn.execute("SELECT * FROM binaries WHERE id = ?", (bid,)).fetchone()
+        builds = [(row['build_date'], row['binary_path'], row['eqgame_h'])]
+    elif args.binary and args.offsets:
+        builds = [('standalone', args.binary, args.offsets)]
+    else:
+        print("Specify --build DATE, --all, or --binary + --offsets")
+        return
+
+    for build_date, binary_path, offsets_path in sorted(builds):
+        print(f"\n{'='*60}")
+        print(f"Build: {build_date}")
+        print(f"{'='*60}")
+
+        cache = os.path.join(os.path.dirname(__file__), '..', '..', 'data',
+                            'disasm_cache', build_date)
+
+        classifications = scan_binary(binary_path, offsets_path,
+                                      (lo, hi), args.workers, cache)
+
+        # Stats
+        high = sum(1 for c in classifications if c[3] == 'HIGH')
+        med = sum(1 for c in classifications if c[3] == 'MED')
+        low = sum(1 for c in classifications if c[3] == 'LOW')
+        unique_offsets = len(set(c[2] for c in classifications))
+
+        print(f"\n  Results: {len(classifications)} total accesses")
+        print(f"  HIGH: {high}, MED: {med}, LOW: {low}")
+        print(f"  Unique offsets covered: {unique_offsets}")
+
+        # Show HIGH confidence findings
+        print(f"\n  HIGH confidence identifications:")
+        for fn, fa, off, conf, etype, detail in sorted(classifications, key=lambda x: x[2]):
+            if conf == 'HIGH':
+                print(f"    0x{off:03x}  {etype:6s}  {fn}")
+
+        if not args.no_db and build_date != 'standalone':
+            bid = db.get_binary_id(build_date)
+            if bid:
+                # Clear old evidence for this build, but preserve gap_analysis records
+                db.conn.execute("""
+                    DELETE FROM evidence_records
+                    WHERE binary_id = ?
+                      AND id NOT IN (
+                          SELECT er.id FROM evidence_records er
+                          JOIN function_identities fi ON er.func_id = fi.id
+                          WHERE er.binary_id = ? AND fi.func_name = 'gap_analysis'
+                      )
+                """, (bid, bid))
+                db.conn.commit()
+                count = populate_db(db, bid, classifications)
+                print(f"\n  Stored {count} evidence records in database")
+
+    if not args.no_db:
+        print(f"\nFinal database stats:")
+        for k, v in db.stats().items():
+            print(f"  {k}: {v}")
+
+    db.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/re_pipeline/distributed_scan.sh
+++ b/tools/re_pipeline/distributed_scan.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# distributed_scan.sh - Farm out rizin accessor scanning to pvehosts
+#
+# Copies eqgame.exe + eqgame.h to each host, runs the disasm scan,
+# copies results back. Uses SSH with -o RemoteCommand=none to bypass zellij.
+#
+set -euo pipefail
+
+HOSTS=(pvehost1 pvehost2 pvehost3 pvehost4)
+SSH_OPTS="-o RemoteCommand=none"
+BUILDS_DIR="/mnt/DEV/reverse-engineering/MQ-RE/eq-builds/live"
+CACHE_DIR="/mnt/DEV/reverse-engineering/MQ-RE/data/disasm_cache"
+WORKERS=48
+
+# Get list of builds that need scanning (no disasm cache yet)
+BUILDS=()
+for dir in "$BUILDS_DIR"/*/; do
+    date=$(basename "$dir")
+    if [ ! -d "$CACHE_DIR/$date" ] || [ $(find "$CACHE_DIR/$date" -name "*.asm" 2>/dev/null | wc -l) -lt 100 ]; then
+        if [ -f "$dir/eqgame.exe" ] && [ -f "$dir/eqgame.h" ]; then
+            BUILDS+=("$date")
+        fi
+    fi
+done
+
+echo "Builds needing scan: ${#BUILDS[@]}"
+printf "  %s\n" "${BUILDS[@]}"
+
+# Distribute builds across hosts (round-robin)
+declare -A HOST_BUILDS
+for i in "${!BUILDS[@]}"; do
+    host_idx=$((i % ${#HOSTS[@]}))
+    host="${HOSTS[$host_idx]}"
+    HOST_BUILDS[$host]+="${BUILDS[$i]} "
+done
+
+echo ""
+for host in "${HOSTS[@]}"; do
+    builds="${HOST_BUILDS[$host]:-none}"
+    echo "$host: $builds"
+done
+
+# For each host, copy files and run scan
+for host in "${HOSTS[@]}"; do
+    builds="${HOST_BUILDS[$host]:-}"
+    if [ -z "$builds" ]; then
+        continue
+    fi
+
+    echo ""
+    echo "=== Setting up $host ==="
+
+    # Create work directory on host
+    ssh $SSH_OPTS "$host" "mkdir -p /tmp/eq_scan" 2>/dev/null
+
+    # Copy the scan script (inline rizin scanner)
+    cat << 'SCANNER' | ssh $SSH_OPTS "$host" "cat > /tmp/eq_scan/scan.py"
+#!/usr/bin/env python3
+import re, os, sys, subprocess
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+def scan_func(exe, addr):
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"af @ {addr}; pdf @ {addr}",
+             exe], capture_output=True, text=True, timeout=10)
+        text = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        return (addr, text)
+    except:
+        return (addr, None)
+
+def main():
+    build_date = sys.argv[1]
+    exe = f"/tmp/eq_scan/{build_date}/eqgame.exe"
+    header = f"/tmp/eq_scan/{build_date}/eqgame.h"
+    out_dir = f"/tmp/eq_scan/{build_date}/disasm"
+    os.makedirs(out_dir, exist_ok=True)
+
+    # Parse function addresses
+    funcs = {}
+    with open(header) as f:
+        for line in f:
+            m = re.match(r'#define\s+(\S+)_x\s+(0x[0-9a-fA-F]+)', line.strip())
+            if m:
+                funcs[m.group(1)] = m.group(2)
+
+    print(f"Scanning {len(funcs)} functions for {build_date}")
+
+    with ProcessPoolExecutor(max_workers=48) as executor:
+        futures = {executor.submit(scan_func, exe, addr): name for name, addr in funcs.items()}
+        done = 0
+        for future in as_completed(futures):
+            name = futures[future]
+            addr, text = future.result()
+            done += 1
+            if text and len(text) > 10:
+                with open(f"{out_dir}/{name}.asm", 'w') as f:
+                    f.write(text)
+            if done % 50 == 0:
+                print(f"  {done}/{len(funcs)}...")
+
+    print(f"Done: {build_date}")
+
+if __name__ == '__main__':
+    main()
+SCANNER
+
+    # Copy binaries and run scan for each assigned build
+    for date in $builds; do
+        echo "  Copying $date to $host..."
+        ssh $SSH_OPTS "$host" "mkdir -p /tmp/eq_scan/$date"
+        scp -q "$BUILDS_DIR/$date/eqgame.exe" "$host:/tmp/eq_scan/$date/"
+        scp -q "$BUILDS_DIR/$date/eqgame.h" "$host:/tmp/eq_scan/$date/"
+
+        echo "  Launching scan for $date on $host..."
+        ssh $SSH_OPTS "$host" "cd /tmp/eq_scan && python3 scan.py $date > /tmp/eq_scan/${date}.log 2>&1" &
+    done
+done
+
+echo ""
+echo "All scans launched. Monitor with:"
+echo "  for h in pvehost{1..4}; do echo \"=== \$h ===\"; ssh $SSH_OPTS \$h 'tail -1 /tmp/eq_scan/*.log 2>/dev/null'; done"
+echo ""
+echo "When done, collect results with:"
+echo "  for h in pvehost{1..4}; do for d in \$(ssh $SSH_OPTS \$h 'ls -d /tmp/eq_scan/20*/disasm 2>/dev/null'); do"
+echo "    date=\$(basename \$(dirname \$d)); mkdir -p $CACHE_DIR/\$date; scp -r \$h:\$d/* $CACHE_DIR/\$date/; done; done"

--- a/tools/re_pipeline/distributed_scan_sequential.sh
+++ b/tools/re_pipeline/distributed_scan_sequential.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# distributed_scan_sequential.sh - Sequential-per-host rizin scanning
+#
+# Runs one build at a time per host (4 hosts = 4 concurrent scans).
+# Each scan uses 48 workers internally, well within the 72 cores per host.
+#
+set -euo pipefail
+
+HOSTS=(pvehost1 pvehost2 pvehost3 pvehost4)
+SSH_OPTS="-o RemoteCommand=none"
+BUILDS_DIR="/mnt/DEV/reverse-engineering/MQ-RE/eq-builds/live"
+CACHE_DIR="/mnt/DEV/reverse-engineering/MQ-RE/data/disasm_cache"
+
+# Get builds needing scan
+BUILDS=()
+for dir in "$BUILDS_DIR"/*/; do
+    date=$(basename "$dir")
+    if [ ! -d "$CACHE_DIR/$date" ] || [ $(find "$CACHE_DIR/$date" -name "*.asm" 2>/dev/null | wc -l) -lt 100 ]; then
+        if [ -f "$dir/eqgame.exe" ] && [ -f "$dir/eqgame.h" ]; then
+            BUILDS+=("$date")
+        fi
+    fi
+done
+
+echo "Builds needing scan: ${#BUILDS[@]}"
+
+# Distribute round-robin
+declare -A HOST_BUILDS
+for i in "${!BUILDS[@]}"; do
+    host_idx=$((i % ${#HOSTS[@]}))
+    host="${HOSTS[$host_idx]}"
+    HOST_BUILDS[$host]+="${BUILDS[$i]} "
+done
+
+for host in "${HOSTS[@]}"; do
+    echo "$host: ${HOST_BUILDS[$host]:-none}"
+done
+
+# Copy scan script to each host
+for host in "${HOSTS[@]}"; do
+    ssh $SSH_OPTS "$host" "mkdir -p /tmp/eq_scan" 2>/dev/null
+
+    cat << 'SCANNER' | ssh $SSH_OPTS "$host" "cat > /tmp/eq_scan/scan.py"
+#!/usr/bin/env python3
+import re, os, sys, subprocess
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+def scan_func(exe, addr):
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"af @ {addr}; pdf @ {addr}",
+             exe], capture_output=True, text=True, timeout=10)
+        text = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        return (addr, text)
+    except:
+        return (addr, None)
+
+def main():
+    build_date = sys.argv[1]
+    exe = f"/tmp/eq_scan/{build_date}/eqgame.exe"
+    header = f"/tmp/eq_scan/{build_date}/eqgame.h"
+    out_dir = f"/tmp/eq_scan/{build_date}/disasm"
+    os.makedirs(out_dir, exist_ok=True)
+
+    funcs = {}
+    with open(header) as f:
+        for line in f:
+            m = re.match(r'#define\s+(\S+)_x\s+(0x[0-9a-fA-F]+)', line.strip())
+            if m:
+                funcs[m.group(1)] = m.group(2)
+
+    print(f"Scanning {len(funcs)} functions for {build_date}")
+
+    with ProcessPoolExecutor(max_workers=48) as executor:
+        futures = {executor.submit(scan_func, exe, addr): name for name, addr in funcs.items()}
+        done = 0
+        for future in as_completed(futures):
+            name = futures[future]
+            addr, text = future.result()
+            done += 1
+            if text and len(text) > 10:
+                with open(f"{out_dir}/{name}.asm", 'w') as f:
+                    f.write(text)
+            if done % 50 == 0:
+                print(f"  {done}/{len(funcs)}...")
+
+    print(f"Done: {build_date}")
+
+if __name__ == '__main__':
+    main()
+SCANNER
+done
+
+# For each host, create a wrapper that runs builds SEQUENTIALLY
+for host in "${HOSTS[@]}"; do
+    builds="${HOST_BUILDS[$host]:-}"
+    if [ -z "$builds" ]; then
+        continue
+    fi
+
+    echo ""
+    echo "=== Setting up $host ==="
+
+    # Copy all build files first
+    for date in $builds; do
+        echo "  Copying $date to $host..."
+        ssh $SSH_OPTS "$host" "mkdir -p /tmp/eq_scan/$date"
+        scp -q "$BUILDS_DIR/$date/eqgame.exe" "$host:/tmp/eq_scan/$date/"
+        scp -q "$BUILDS_DIR/$date/eqgame.h" "$host:/tmp/eq_scan/$date/"
+    done
+
+    # Create sequential runner script
+    build_list=""
+    for date in $builds; do
+        build_list+="$date "
+    done
+
+    ssh $SSH_OPTS "$host" "cat > /tmp/eq_scan/run_all.sh" << RUNNER
+#!/bin/bash
+for date in $build_list; do
+    echo "[\$(date '+%H:%M:%S')] Starting \$date"
+    python3 /tmp/eq_scan/scan.py \$date >> /tmp/eq_scan/\${date}.log 2>&1
+    echo "[\$(date '+%H:%M:%S')] Finished \$date"
+done
+echo "ALL DONE on \$(hostname)"
+RUNNER
+
+    # Launch sequential runner in background
+    echo "  Launching sequential scan on $host..."
+    ssh $SSH_OPTS "$host" "nohup bash /tmp/eq_scan/run_all.sh > /tmp/eq_scan/master.log 2>&1 &" &
+done
+
+wait
+
+echo ""
+echo "All hosts launched (sequential per host). Monitor with:"
+echo "  for h in pvehost{1..4}; do echo \"=== \$h ===\"; ssh $SSH_OPTS \$h 'cat /tmp/eq_scan/master.log 2>/dev/null | tail -5'; done"
+echo ""
+echo "When done, collect results with:"
+echo "  for h in pvehost{1..4}; do"
+echo "    for d in \$(ssh $SSH_OPTS \$h 'ls -d /tmp/eq_scan/20*/disasm 2>/dev/null'); do"
+echo "      date=\$(basename \$(dirname \$d))"
+echo "      mkdir -p $CACHE_DIR/\$date"
+echo "      rsync -a \$h:\$d/ $CACHE_DIR/\$date/"
+echo "    done"
+echo "  done"

--- a/tools/re_pipeline/eq_xref_db.py
+++ b/tools/re_pipeline/eq_xref_db.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""
+eq_xref_db.py - Persistent cross-reference database for EQ struct member tracking.
+
+Tracks where each struct member lives in each binary version and which
+functions access it. Accumulates knowledge across patches so each
+successive patch day gets easier.
+
+All other scripts should import from here -- don't call sqlite3.connect directly.
+"""
+
+import sqlite3
+import re
+import os
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_DB_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'data', 'eq_xref.db')
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS binaries (
+    id           INTEGER PRIMARY KEY,
+    build_date   TEXT    UNIQUE NOT NULL,
+    server       TEXT    NOT NULL DEFAULT 'live',
+    binary_path  TEXT    NOT NULL,
+    eqgame_h     TEXT,
+    client_date  INTEGER,
+    image_base   INTEGER DEFAULT 0x140000000,
+    added_at     TEXT    DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS struct_members (
+    id           INTEGER PRIMARY KEY,
+    class_name   TEXT    NOT NULL,
+    field_name   TEXT    NOT NULL,
+    field_type   TEXT,
+    field_size   INTEGER,
+    notes        TEXT,
+    UNIQUE(class_name, field_name)
+);
+
+CREATE TABLE IF NOT EXISTS member_offsets (
+    id           INTEGER PRIMARY KEY,
+    binary_id    INTEGER NOT NULL REFERENCES binaries(id),
+    member_id    INTEGER NOT NULL REFERENCES struct_members(id),
+    offset_val   INTEGER NOT NULL,
+    confidence   TEXT    NOT NULL
+                 CHECK(confidence IN ('GROUND_TRUTH','HIGH','MED','LOW')),
+    source       TEXT,
+    UNIQUE(binary_id, member_id)
+);
+
+CREATE TABLE IF NOT EXISTS function_identities (
+    id           INTEGER PRIMARY KEY,
+    binary_id    INTEGER NOT NULL REFERENCES binaries(id),
+    func_name    TEXT    NOT NULL,
+    func_addr    INTEGER NOT NULL,
+    UNIQUE(binary_id, func_name)
+);
+
+CREATE TABLE IF NOT EXISTS evidence_records (
+    id              INTEGER PRIMARY KEY,
+    binary_id       INTEGER NOT NULL REFERENCES binaries(id),
+    member_id       INTEGER NOT NULL REFERENCES struct_members(id),
+    func_id         INTEGER NOT NULL REFERENCES function_identities(id),
+    evidence_type   TEXT    NOT NULL
+                    CHECK(evidence_type IN ('setter','getter','ini_key','destructor','xref','access')),
+    decompile_line  TEXT,
+    confidence      TEXT    NOT NULL
+                    CHECK(confidence IN ('HIGH','MED','LOW'))
+);
+
+CREATE TABLE IF NOT EXISTS bindiff_matches (
+    id           INTEGER PRIMARY KEY,
+    old_binary   INTEGER NOT NULL REFERENCES binaries(id),
+    new_binary   INTEGER NOT NULL REFERENCES binaries(id),
+    old_addr     INTEGER NOT NULL,
+    new_addr     INTEGER NOT NULL,
+    similarity   REAL,
+    UNIQUE(old_binary, new_binary, old_addr)
+);
+
+CREATE INDEX IF NOT EXISTS idx_offsets_binary_offset ON member_offsets(binary_id, offset_val);
+CREATE INDEX IF NOT EXISTS idx_offsets_member ON member_offsets(member_id);
+CREATE INDEX IF NOT EXISTS idx_evidence_member ON evidence_records(member_id);
+CREATE INDEX IF NOT EXISTS idx_bindiff_lookup ON bindiff_matches(old_binary, old_addr);
+CREATE INDEX IF NOT EXISTS idx_func_binary ON function_identities(binary_id, func_name);
+"""
+
+
+class EQXrefDB:
+    def __init__(self, db_path: str = DEFAULT_DB_PATH):
+        self.db_path = os.path.abspath(db_path)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.execute("PRAGMA foreign_keys=ON")
+        self.conn.executescript(SCHEMA)
+
+    def close(self):
+        self.conn.close()
+
+    # -- Build registration --
+
+    def add_binary(self, build_date: str, binary_path: str,
+                   eqgame_h_path: str = None, server: str = 'live',
+                   client_date: int = None) -> int:
+        cur = self.conn.execute(
+            """INSERT OR IGNORE INTO binaries (build_date, server, binary_path, eqgame_h, client_date)
+               VALUES (?, ?, ?, ?, ?)""",
+            (build_date, server, binary_path, eqgame_h_path, client_date))
+        self.conn.commit()
+        if cur.lastrowid:
+            return cur.lastrowid
+        return self.get_binary_id(build_date)
+
+    def get_binary_id(self, build_date: str) -> Optional[int]:
+        row = self.conn.execute(
+            "SELECT id FROM binaries WHERE build_date = ?", (build_date,)).fetchone()
+        return row['id'] if row else None
+
+    def list_binaries(self) -> list:
+        rows = self.conn.execute(
+            "SELECT * FROM binaries ORDER BY build_date").fetchall()
+        return [dict(r) for r in rows]
+
+    # -- Member catalog --
+
+    def ensure_member(self, class_name: str, field_name: str,
+                      field_type: str = None, field_size: int = None) -> int:
+        self.conn.execute(
+            """INSERT OR IGNORE INTO struct_members (class_name, field_name, field_type, field_size)
+               VALUES (?, ?, ?, ?)""",
+            (class_name, field_name, field_type, field_size))
+        self.conn.commit()
+        return self.get_member_id(class_name, field_name)
+
+    def get_member_id(self, class_name: str, field_name: str) -> Optional[int]:
+        row = self.conn.execute(
+            "SELECT id FROM struct_members WHERE class_name = ? AND field_name = ?",
+            (class_name, field_name)).fetchone()
+        return row['id'] if row else None
+
+    # -- Ground truth ingestion from eqgame.h --
+
+    def ingest_eqgame_h(self, binary_id: int, header_path: str):
+        """Parse eqgame.h and store function addresses."""
+        with open(header_path) as f:
+            content = f.read()
+
+        count = 0
+        for m in re.finditer(r'^#define\s+(\S+)_x\s+(0x[0-9a-fA-F]+)', content, re.MULTILINE):
+            func_name = m.group(1)
+            addr = int(m.group(2), 16)
+            self.conn.execute(
+                """INSERT OR REPLACE INTO function_identities (binary_id, func_name, func_addr)
+                   VALUES (?, ?, ?)""",
+                (binary_id, func_name, addr))
+            count += 1
+
+        # Also grab __ClientDate
+        cd_match = re.search(r'__ClientDate\s+(\d+)', content)
+        if cd_match:
+            self.conn.execute(
+                "UPDATE binaries SET client_date = ? WHERE id = ?",
+                (int(cd_match.group(1)), binary_id))
+
+        self.conn.commit()
+        return count
+
+    def ingest_struct_header(self, binary_id: int, header_path: str,
+                             class_name: str, start_marker: str = None,
+                             end_marker: str = None):
+        """Parse a struct header (CXWnd.h etc) for member offsets.
+
+        Looks for lines like: /*0x030*/ int  BottomOffset;
+        between optional start/end markers.
+        """
+        with open(header_path) as f:
+            content = f.read()
+
+        if start_marker:
+            idx = content.find(start_marker)
+            if idx >= 0:
+                content = content[idx:]
+        if end_marker:
+            idx = content.find(end_marker)
+            if idx >= 0:
+                content = content[:idx]
+
+        member_re = re.compile(
+            r'/\*0x([0-9a-fA-F]+)\*/\s+(\S+(?:\s*\*)?)\s+(\w+)\s*;')
+
+        count = 0
+        for m in member_re.finditer(content):
+            offset = int(m.group(1), 16)
+            field_type = m.group(2)
+            field_name = m.group(3)
+
+            if field_name.startswith('Pad'):
+                continue
+
+            member_id = self.ensure_member(class_name, field_name, field_type)
+            self.conn.execute(
+                """INSERT OR REPLACE INTO member_offsets
+                   (binary_id, member_id, offset_val, confidence, source)
+                   VALUES (?, ?, ?, 'GROUND_TRUTH', 'header_parse')""",
+                (binary_id, member_id, offset))
+            count += 1
+
+        self.conn.commit()
+        return count
+
+    # -- Offset queries --
+
+    def get_offset(self, binary_id: int, class_name: str,
+                   field_name: str) -> Optional[int]:
+        row = self.conn.execute("""
+            SELECT mo.offset_val FROM member_offsets mo
+            JOIN struct_members sm ON mo.member_id = sm.id
+            WHERE mo.binary_id = ? AND sm.class_name = ? AND sm.field_name = ?
+        """, (binary_id, class_name, field_name)).fetchone()
+        return row['offset_val'] if row else None
+
+    def get_member_at_offset(self, binary_id: int, class_name: str,
+                             offset: int) -> Optional[dict]:
+        row = self.conn.execute("""
+            SELECT sm.field_name, sm.field_type, mo.confidence, mo.source
+            FROM member_offsets mo
+            JOIN struct_members sm ON mo.member_id = sm.id
+            WHERE mo.binary_id = ? AND sm.class_name = ? AND mo.offset_val = ?
+        """, (binary_id, class_name, offset)).fetchone()
+        return dict(row) if row else None
+
+    def get_member_history(self, class_name: str, field_name: str) -> list:
+        rows = self.conn.execute("""
+            SELECT b.build_date, b.server, mo.offset_val, mo.confidence, mo.source
+            FROM member_offsets mo
+            JOIN struct_members sm ON mo.member_id = sm.id
+            JOIN binaries b ON mo.binary_id = b.id
+            WHERE sm.class_name = ? AND sm.field_name = ?
+            ORDER BY b.build_date
+        """, (class_name, field_name)).fetchall()
+        return [dict(r) for r in rows]
+
+    # -- Evidence records --
+
+    def add_evidence(self, binary_id: int, class_name: str, field_name: str,
+                     func_name: str, func_addr: int, evidence_type: str,
+                     decompile_line: str = None, confidence: str = 'HIGH'):
+        member_id = self.ensure_member(class_name, field_name)
+
+        # Ensure function exists
+        self.conn.execute(
+            """INSERT OR IGNORE INTO function_identities (binary_id, func_name, func_addr)
+               VALUES (?, ?, ?)""",
+            (binary_id, func_name, func_addr))
+        self.conn.commit()
+
+        func_row = self.conn.execute(
+            "SELECT id FROM function_identities WHERE binary_id = ? AND func_name = ?",
+            (binary_id, func_name)).fetchone()
+
+        self.conn.execute(
+            """INSERT INTO evidence_records
+               (binary_id, member_id, func_id, evidence_type, decompile_line, confidence)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (binary_id, member_id, func_row['id'], evidence_type, decompile_line, confidence))
+        self.conn.commit()
+
+    def get_evidence(self, class_name: str, field_name: str) -> list:
+        rows = self.conn.execute("""
+            SELECT b.build_date, fi.func_name, fi.func_addr,
+                   er.evidence_type, er.decompile_line, er.confidence
+            FROM evidence_records er
+            JOIN struct_members sm ON er.member_id = sm.id
+            JOIN function_identities fi ON er.func_id = fi.id
+            JOIN binaries b ON er.binary_id = b.id
+            WHERE sm.class_name = ? AND sm.field_name = ?
+            ORDER BY b.build_date
+        """, (class_name, field_name)).fetchall()
+        return [dict(r) for r in rows]
+
+    # -- Function identity --
+
+    def add_function(self, binary_id: int, func_name: str, func_addr: int) -> int:
+        self.conn.execute(
+            """INSERT OR REPLACE INTO function_identities (binary_id, func_name, func_addr)
+               VALUES (?, ?, ?)""",
+            (binary_id, func_name, func_addr))
+        self.conn.commit()
+        row = self.conn.execute(
+            "SELECT id FROM function_identities WHERE binary_id = ? AND func_name = ?",
+            (binary_id, func_name)).fetchone()
+        return row['id']
+
+    def get_function_addr(self, binary_id: int, func_name: str) -> Optional[int]:
+        row = self.conn.execute(
+            "SELECT func_addr FROM function_identities WHERE binary_id = ? AND func_name = ?",
+            (binary_id, func_name)).fetchone()
+        return row['func_addr'] if row else None
+
+    # -- BinDiff data --
+
+    def ingest_bindiff(self, old_binary_id: int, new_binary_id: int,
+                       bindiff_db_path: str) -> int:
+        """Import function matches from a BinDiff .BinDiff SQLite file."""
+        bd_conn = sqlite3.connect(bindiff_db_path)
+        bd_conn.row_factory = sqlite3.Row
+
+        rows = bd_conn.execute("""
+            SELECT address1, address2, similarity
+            FROM function
+            WHERE similarity > 0.3
+        """).fetchall()
+
+        count = 0
+        for row in rows:
+            self.conn.execute(
+                """INSERT OR IGNORE INTO bindiff_matches
+                   (old_binary, new_binary, old_addr, new_addr, similarity)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (old_binary_id, new_binary_id,
+                 row['address1'], row['address2'], row['similarity']))
+            count += 1
+
+        bd_conn.close()
+        self.conn.commit()
+        return count
+
+    def translate_address(self, old_binary_id: int, new_binary_id: int,
+                          old_addr: int) -> Optional[int]:
+        row = self.conn.execute("""
+            SELECT new_addr FROM bindiff_matches
+            WHERE old_binary = ? AND new_binary = ? AND old_addr = ?
+        """, (old_binary_id, new_binary_id, old_addr)).fetchone()
+        return row['new_addr'] if row else None
+
+    # -- Patch day helpers --
+
+    def find_identifying_functions(self, class_name: str,
+                                   field_name: str) -> list:
+        """Find functions that consistently identify a field across builds.
+
+        Returns functions ranked by how many builds they appear in with
+        HIGH confidence evidence.
+        """
+        rows = self.conn.execute("""
+            SELECT fi.func_name, er.evidence_type, COUNT(DISTINCT b.id) as build_count,
+                   GROUP_CONCAT(DISTINCT b.build_date) as builds
+            FROM evidence_records er
+            JOIN struct_members sm ON er.member_id = sm.id
+            JOIN function_identities fi ON er.func_id = fi.id
+            JOIN binaries b ON er.binary_id = b.id
+            WHERE sm.class_name = ? AND sm.field_name = ?
+              AND er.confidence = 'HIGH'
+            GROUP BY fi.func_name, er.evidence_type
+            ORDER BY build_count DESC
+        """, (class_name, field_name)).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_all_members(self, class_name: str, binary_id: int) -> list:
+        """Get all known member offsets for a class in a specific build."""
+        rows = self.conn.execute("""
+            SELECT sm.field_name, sm.field_type, mo.offset_val, mo.confidence, mo.source
+            FROM member_offsets mo
+            JOIN struct_members sm ON mo.member_id = sm.id
+            WHERE sm.class_name = ? AND mo.binary_id = ?
+            ORDER BY mo.offset_val
+        """, (class_name, binary_id)).fetchall()
+        return [dict(r) for r in rows]
+
+    def stats(self) -> dict:
+        """Quick summary stats."""
+        return {
+            'binaries': self.conn.execute("SELECT COUNT(*) FROM binaries").fetchone()[0],
+            'members': self.conn.execute("SELECT COUNT(*) FROM struct_members").fetchone()[0],
+            'offsets': self.conn.execute("SELECT COUNT(*) FROM member_offsets").fetchone()[0],
+            'functions': self.conn.execute("SELECT COUNT(*) FROM function_identities").fetchone()[0],
+            'evidence': self.conn.execute("SELECT COUNT(*) FROM evidence_records").fetchone()[0],
+            'bindiff': self.conn.execute("SELECT COUNT(*) FROM bindiff_matches").fetchone()[0],
+        }
+
+
+if __name__ == '__main__':
+    import sys
+    db = EQXrefDB()
+    if len(sys.argv) > 1 and sys.argv[1] == 'stats':
+        for k, v in db.stats().items():
+            print(f"  {k}: {v}")
+    else:
+        print(f"Database: {db.db_path}")
+        print("Run with 'stats' to see counts.")
+    db.close()

--- a/tools/re_pipeline/eqgame_h_generator.py
+++ b/tools/re_pipeline/eqgame_h_generator.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+eqgame.h address translator for EQ patch day.
+
+Three-layer approach, each 100% accurate for its category:
+1. BinDiff function matching -- direct lookup for function-start entries (~545)
+2. Xref following -- find code referencing old address, use BinDiff instruction
+   mapping to find same code in new binary, read new address from operands (~103)
+3. Sub-function signature matching -- for entries with 0 xrefs, match instruction
+   patterns within BinDiff-matched containing functions (~3)
+
+Usage:
+    python3 eqgame_h_generator.py \
+        --old-binary OLD --new-binary NEW \
+        --old-header OLD_H --bindiff-db DB \
+        --old-xrefs OLD_XREFS.json \
+        --generate new_eqgame.h \
+        [--new-header ANSWER_KEY]
+"""
+
+import os
+import re
+import json
+import sqlite3
+import bisect
+import subprocess
+import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+
+def parse_eqgame_h(path):
+    entries = {}
+    with open(path) as f:
+        for line in f:
+            m = re.match(r'#define\s+(\w+)_x\s+(0x[0-9a-fA-F]+)', line.strip())
+            if m:
+                entries[m.group(1)] = int(m.group(2), 16)
+    return entries
+
+
+def load_bindiff(db_path):
+    db = sqlite3.connect(db_path)
+    c = db.cursor()
+    c.execute("SELECT address1, address2 FROM function")
+    funcs = {a1: a2 for a1, a2 in c.fetchall()}
+    c.execute("SELECT address1, address2 FROM instruction")
+    instrs = {a1: a2 for a1, a2 in c.fetchall()}
+    db.close()
+    return funcs, instrs
+
+
+# ── Layer 2: Xref following ──────────────────────────────────────────
+
+def read_refs_from_instruction(binary, instr_addr):
+    """Read addresses referenced by the instruction, excluding its own address."""
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"pd 1 @ {instr_addr}", binary],
+            capture_output=True, text=True, timeout=10
+        )
+        clean = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        refs = set()
+        for m in re.finditer(r'0x(14[0-9a-f]{7,8})', clean, re.I):
+            addr = int(m.group(0), 16)
+            if addr != instr_addr:
+                refs.add(addr)
+        return list(refs)
+    except Exception:
+        return []
+
+
+def xref_translate(name, old_addr, old_xrefs_data, instr_map, new_binary):
+    """Translate address via xref following + BinDiff instruction mapping."""
+    xrefs = old_xrefs_data.get("xrefs", [])
+    if not xrefs:
+        return None, "no_xrefs"
+
+    for xref in xrefs:
+        from_addr = int(xref["from"], 16)
+        old_refs = [int(r, 16) for r in xref.get("refs_from", [])]
+
+        if old_addr not in old_refs:
+            continue
+
+        new_from = instr_map.get(from_addr)
+        if new_from is None:
+            continue
+
+        refs = read_refs_from_instruction(new_binary, new_from)
+        if refs:
+            if len(refs) == 1:
+                return refs[0], "xref"
+            return min(refs, key=lambda r: abs(r - old_addr)), "xref_multi"
+
+    return None, "xref_no_match"
+
+
+# ── Layer 3: Sub-function signature matching ─────────────────────────
+
+def disassemble_range(binary, start_addr, num_instructions):
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"pd {num_instructions} @ {start_addr}", binary],
+            capture_output=True, text=True, timeout=15
+        )
+        clean = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        instructions = []
+        for line in clean.split('\n'):
+            m = re.match(r'\s*[^0-9a-fA-F]*(0x[0-9a-f]+)\s+(\w+)\s*(.*)', line.strip())
+            if m:
+                addr = int(m.group(1), 16)
+                mnemonic = m.group(2)
+                operands = re.sub(r'\s*;.*', '', m.group(3).strip())
+                instructions.append((addr, mnemonic, operands))
+        return instructions
+    except Exception:
+        return []
+
+
+def normalize_operands(operands):
+    def replace_addr(m):
+        addr = int(m.group(0), 16)
+        return m.group(0) if addr >= 0x140800000 else '*'
+    s = re.sub(r'0x[0-9a-fA-F]+', replace_addr, operands)
+    s = re.sub(r'\b\d+\b', '*', s)
+    s = re.sub(r'\b(byte|word|dword|qword)\b', '', s)
+    return s.strip()
+
+
+def make_signature(instructions, length=8):
+    return [(m, normalize_operands(o)) for _, m, o in instructions[:length]]
+
+
+def subfunc_match(args):
+    """Match a sub-function entry via instruction signature."""
+    name, old_addr, old_func, new_func, old_bin, new_bin, func_size = args
+
+    old_instrs = disassemble_range(old_bin, old_addr, 12)
+    if len(old_instrs) < 3:
+        return name, old_addr, None, "insufficient_disasm"
+
+    sig = make_signature(old_instrs)
+    num_instr = max(func_size // 3, 50)
+    new_instrs = disassemble_range(new_bin, new_func, num_instr)
+
+    # Scan for matches using core signature (first 3 instructions)
+    core = sig[:3]
+    best_addr = None
+    best_score = 0.0
+
+    for start in range(len(new_instrs) - len(core) + 1):
+        score = 0
+        valid = 0
+        for i, (sm, so) in enumerate(core):
+            _, cm, co = new_instrs[start + i]
+            if cm == 'invalid':
+                break
+            valid += 1
+            if sm == cm:
+                score += 0.5
+                if so == normalize_operands(co):
+                    score += 0.5
+        if valid >= 2:
+            score /= valid
+            if score > best_score:
+                best_score = score
+                best_addr = new_instrs[start][0]
+
+    # Offset translation as cross-check
+    old_offset = old_addr - old_func
+    offset_predicted = new_func + old_offset
+
+    if best_addr and best_score >= 0.7:
+        # Verify: if signature match is far from offset prediction,
+        # prefer offset (signature may have matched a duplicate pattern)
+        sig_offset = best_addr - new_func
+        if abs(sig_offset - old_offset) > old_offset * 0.15 + 0x20:
+            # Signature found something too far from expected position
+            # Verify offset translation with the core signature
+            check = disassemble_range(new_bin, offset_predicted, 4)
+            if len(check) >= 2:
+                check_sig = make_signature(check, 2)
+                match = sum(1 for s, c in zip(sig[:2], check_sig) if s == c)
+                if match >= 1:
+                    return name, old_addr, offset_predicted, "offset_verified"
+            return name, old_addr, best_addr, "signature"
+        return name, old_addr, best_addr, "signature"
+
+    return name, old_addr, offset_predicted, "offset_fallback"
+
+
+# ── Header generation ────────────────────────────────────────────────
+
+def generate_header(old_header_path, translations, output_path):
+    with open(old_header_path) as f:
+        content = f.read()
+    replacements = 0
+    for name, new_addr in translations.items():
+        pattern = rf'(#define\s+{re.escape(name)}_x\s+)0x[0-9a-fA-F]+'
+        new_content = re.sub(pattern, rf'\g<1>0x{new_addr:X}', content)
+        if new_content != content:
+            replacements += 1
+            content = new_content
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, 'w') as f:
+        f.write(content)
+    print(f"  Generated {output_path} ({replacements} addresses updated)")
+
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="eqgame.h address translator")
+    parser.add_argument("--old-binary", required=True)
+    parser.add_argument("--new-binary", required=True)
+    parser.add_argument("--old-header", required=True)
+    parser.add_argument("--new-header", help="Answer key (scoring only)")
+    parser.add_argument("--bindiff-db", required=True)
+    parser.add_argument("--old-xrefs", required=True, help="Old binary xrefs JSON from ExtractReferences")
+    parser.add_argument("--workers", type=int, default=32)
+    parser.add_argument("--output", default="results.json")
+    parser.add_argument("--generate", help="Path for generated eqgame.h")
+    args = parser.parse_args()
+
+    print("Loading data...")
+    old_entries = parse_eqgame_h(args.old_header)
+    func_map, instr_map = load_bindiff(args.bindiff_db)
+    func_sorted = sorted(func_map.keys())
+
+    with open(args.old_xrefs) as f:
+        old_xrefs = json.load(f)
+
+    translations = {}
+    methods = {}
+    subfunc_queue = []
+
+    # ── Layer 1: BinDiff function matching ───────────────────────────
+    for name, old_addr in old_entries.items():
+        if old_addr in func_map:
+            translations[name] = func_map[old_addr]
+            methods[name] = "bindiff"
+
+    layer1 = len(translations)
+    print(f"  Layer 1 (BinDiff functions): {layer1}")
+
+    # ── Layer 2: Xref following ──────────────────────────────────────
+    remaining = {n: a for n, a in old_entries.items() if n not in translations}
+    print(f"  Layer 2 (xref following): processing {len(remaining)} entries...")
+
+    for name, old_addr in remaining.items():
+        xref_data = old_xrefs.get(name, {})
+        new_addr, status = xref_translate(
+            name, old_addr, xref_data, instr_map, args.new_binary
+        )
+        if new_addr is not None:
+            translations[name] = new_addr
+            methods[name] = status
+        else:
+            # Queue for layer 3
+            idx = bisect.bisect_right(func_sorted, old_addr) - 1
+            if idx >= 0 and 0 < old_addr - func_sorted[idx] < 0x5000:
+                func_start = func_sorted[idx]
+                new_func = func_map[func_start]
+                next_func = func_sorted[idx + 1] if idx + 1 < len(func_sorted) else func_start + 0x2000
+                subfunc_queue.append({
+                    "name": name, "old_addr": old_addr,
+                    "old_func": func_start, "new_func": new_func,
+                    "func_size": next_func - func_start,
+                })
+            else:
+                # No xrefs and no containing function -- carry forward
+                translations[name] = old_addr
+                methods[name] = "carry_forward"
+
+    layer2 = len(translations) - layer1
+    print(f"  Layer 2 results: {layer2} translated")
+
+    # ── Layer 3: Sub-function signature matching ─────────────────────
+    if subfunc_queue:
+        print(f"  Layer 3 (signature matching): {len(subfunc_queue)} entries...")
+        work = [
+            (e["name"], e["old_addr"], e["old_func"], e["new_func"],
+             args.old_binary, args.new_binary, e["func_size"])
+            for e in subfunc_queue
+        ]
+        with ProcessPoolExecutor(max_workers=args.workers) as executor:
+            futures = {executor.submit(subfunc_match, w): w[0] for w in work}
+            for future in as_completed(futures):
+                name, old_addr, new_addr, status = future.result()
+                if new_addr is not None:
+                    translations[name] = new_addr
+                    methods[name] = f"subfunc_{status}"
+                else:
+                    translations[name] = old_addr
+                    methods[name] = "subfunc_failed"
+
+    # ── Layer 4: Derive from related entries ────────────────────────
+    # Some entries have 0 xrefs but can be derived from neighbors.
+    # E.g., __ThrottleFrameRateEnd = __ThrottleFrameRate + instruction_size
+    # We detect these by finding entries whose old addresses are within a
+    # few bytes of another entry, and apply the same delta.
+    weak = [n for n, m in methods.items()
+            if m in ("carry_forward", "subfunc_offset_fallback", "subfunc_failed")]
+    if weak:
+        derived = 0
+        for name in weak:
+            old_addr = old_entries[name]
+            # Look for a related entry within 16 bytes that was confidently translated
+            for other_name, other_old in old_entries.items():
+                if other_name == name:
+                    continue
+                delta = old_addr - other_old
+                if abs(delta) <= 16 and other_name in translations:
+                    other_method = methods.get(other_name, "")
+                    if other_method not in ("carry_forward", "subfunc_offset_fallback",
+                                            "subfunc_failed"):
+                        translations[name] = translations[other_name] + delta
+                        methods[name] = f"derived_from_{other_name}"
+                        derived += 1
+                        break
+        if derived:
+            print(f"  Layer 4 (derived): {derived} entries")
+
+    # For remaining subfunc entries, try offset translation from the
+    # BinDiff-matched containing function (last resort but often correct
+    # when the offset is small and function similarity is high).
+    still_weak = [n for n, m in methods.items()
+                  if m in ("carry_forward", "subfunc_offset_fallback", "subfunc_failed")]
+    for name in still_weak:
+        old_addr = old_entries[name]
+        idx = bisect.bisect_right(func_sorted, old_addr) - 1
+        if idx >= 0:
+            func_start = func_sorted[idx]
+            offset = old_addr - func_start
+            if 0 < offset < 0x5000 and func_start in func_map:
+                new_func = func_map[func_start]
+                translations[name] = new_func + offset
+                methods[name] = "offset_translation"
+
+    # ── Results ──────────────────────────────────────────────────────
+    method_counts = {}
+    for m in methods.values():
+        method_counts[m] = method_counts.get(m, 0) + 1
+
+    print(f"\n{'='*60}")
+    print("RESULTS")
+    print(f"{'='*60}")
+    print(f"Total:       {len(old_entries)}")
+    print(f"Translated:  {len(translations)}")
+    for m, count in sorted(method_counts.items(), key=lambda x: -x[1]):
+        print(f"  {m:35s} {count}")
+
+    # Score
+    if args.new_header:
+        new_entries = parse_eqgame_h(args.new_header)
+        correct = wrong = 0
+        wrong_list = []
+        for name, predicted in translations.items():
+            expected = new_entries.get(name)
+            if expected is None:
+                continue
+            if predicted == expected:
+                correct += 1
+            else:
+                wrong += 1
+                if len(wrong_list) < 30:
+                    wrong_list.append(
+                        f"  [{methods[name]}] {name}: "
+                        f"got 0x{predicted:X}, expected 0x{expected:X}, "
+                        f"diff={predicted-expected:+d}"
+                    )
+        scored = correct + wrong
+        print(f"\n{'='*60}")
+        print("SCORING")
+        print(f"{'='*60}")
+        print(f"Correct: {correct}/{scored} ({100*correct//scored if scored else 0}%)")
+        print(f"Wrong:   {wrong}/{scored}")
+        if wrong_list:
+            for w in wrong_list:
+                print(w)
+
+    # Generate header
+    if args.generate:
+        generate_header(args.old_header, translations, args.generate)
+
+    # Save JSON
+    output = {
+        "summary": {
+            "total": len(old_entries),
+            "translated": len(translations),
+            "methods": method_counts,
+        },
+        "translations": {n: f"0x{a:X}" for n, a in translations.items()},
+        "methods": methods,
+    }
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+    with open(args.output, 'w') as f:
+        json.dump(output, f, indent=2)
+    print(f"\nResults saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/re_pipeline/extract_2024_headers.py
+++ b/tools/re_pipeline/extract_2024_headers.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+extract_2024_headers.py - Extract eqgame.h ground truth for 2024 builds from eqlib git history.
+
+Walks the eqlib-history repo's live branch, finds commits whose __ClientDate
+matches our 2024 build dates, and extracts eqgame.h + CXWnd.h to the build dirs.
+Also registers the builds in the xref database.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from eq_xref_db import EQXrefDB
+
+EQLIB_REPO = os.path.join(os.path.dirname(__file__), '..', '..', 'eqlib-history')
+BUILDS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'eq-builds', 'live')
+
+
+def get_all_clientdates():
+    """Get all commits on live branch with their __ClientDate values."""
+    # Get all commits on live branch
+    result = subprocess.run(
+        ['git', '-C', EQLIB_REPO, 'log', 'live', '--oneline', '--format=%H'],
+        capture_output=True, text=True)
+    commits = result.stdout.strip().split('\n')
+
+    date_to_commit = {}
+    for commit in commits:
+        if not commit:
+            continue
+        # Get __ClientDate from eqgame.h at this commit
+        # Try both old path (root) and new path (include/eqlib/offsets/)
+        for path in ['eqgame.h', 'include/eqlib/offsets/eqgame.h']:
+            try:
+                result = subprocess.run(
+                    ['git', '-C', EQLIB_REPO, 'show', f'{commit}:{path}'],
+                    capture_output=True, text=True, timeout=5)
+                if result.returncode == 0:
+                    m = re.search(r'__ClientDate\s+(\d+)', result.stdout)
+                    if m:
+                        cdate = m.group(1).rstrip('u')
+                        # Convert YYYYMMDD to YYYY-MM-DD
+                        if len(cdate) == 8:
+                            formatted = f"{cdate[:4]}-{cdate[4:6]}-{cdate[6:8]}"
+                            date_to_commit[formatted] = (commit, path)
+                    break
+            except:
+                continue
+
+    return date_to_commit
+
+
+def extract_header(commit, path, output_path):
+    """Extract a file from git at a specific commit."""
+    result = subprocess.run(
+        ['git', '-C', EQLIB_REPO, 'show', f'{commit}:{path}'],
+        capture_output=True, text=True)
+    if result.returncode == 0:
+        with open(output_path, 'w') as f:
+            f.write(result.stdout)
+        return True
+    return False
+
+
+def main():
+    db = EQXrefDB()
+
+    # Get our 2024 build directories
+    build_dirs = sorted([d for d in os.listdir(BUILDS_DIR) if d.startswith('2024-')])
+    print(f"Found {len(build_dirs)} build directories from 2024")
+
+    # Get clientdate→commit mapping from git
+    print("Scanning eqlib git history for ClientDates...")
+    date_to_commit = get_all_clientdates()
+    print(f"Found {len(date_to_commit)} unique ClientDates in git")
+
+    matched = 0
+    unmatched = []
+
+    for build_date in build_dirs:
+        build_dir = os.path.join(BUILDS_DIR, build_date)
+        exe_path = os.path.join(build_dir, 'eqgame.exe')
+        h_path = os.path.join(build_dir, 'eqgame.h')
+
+        if not os.path.exists(exe_path):
+            print(f"  {build_date}: no eqgame.exe, skipping")
+            continue
+
+        if os.path.exists(h_path):
+            print(f"  {build_date}: eqgame.h already exists")
+            matched += 1
+            # Still register in DB if not there
+            bid = db.get_binary_id(build_date)
+            if not bid:
+                bid = db.add_binary(build_date, exe_path, h_path)
+                count = db.ingest_eqgame_h(bid, h_path)
+                print(f"    Registered in DB: {count} functions")
+            continue
+
+        # Try to match this build date to a git ClientDate
+        if build_date in date_to_commit:
+            commit, git_path = date_to_commit[build_date]
+            print(f"  {build_date}: exact match → commit {commit[:8]}")
+        else:
+            # Try nearby dates (build date might be 1-2 days off from ClientDate)
+            found = False
+            year, month, day = build_date.split('-')
+            from datetime import date, timedelta
+            base_date = date(int(year), int(month), int(day))
+            for delta in range(-3, 4):
+                check = base_date + timedelta(days=delta)
+                check_str = check.strftime('%Y-%m-%d')
+                if check_str in date_to_commit:
+                    commit, git_path = date_to_commit[check_str]
+                    print(f"  {build_date}: matched to ClientDate {check_str} → commit {commit[:8]}")
+                    found = True
+                    break
+            if not found:
+                unmatched.append(build_date)
+                print(f"  {build_date}: NO MATCH in git history")
+                continue
+
+        # Extract eqgame.h
+        if extract_header(commit, git_path, h_path):
+            print(f"    Extracted eqgame.h ({os.path.getsize(h_path)} bytes)")
+            matched += 1
+
+            # Also try CXWnd.h
+            for cxwnd_path in ['CXWnd.h', 'include/eqlib/game/CXWnd.h']:
+                cxwnd_out = os.path.join(build_dir, 'CXWnd.h')
+                if extract_header(commit, cxwnd_path, cxwnd_out):
+                    print(f"    Extracted CXWnd.h")
+                    break
+
+            # Register in database
+            bid = db.get_binary_id(build_date)
+            if not bid:
+                bid = db.add_binary(build_date, exe_path, h_path)
+            else:
+                # Update eqgame_h path
+                db.conn.execute("UPDATE binaries SET eqgame_h = ? WHERE id = ?", (h_path, bid))
+                db.conn.commit()
+
+            count = db.ingest_eqgame_h(bid, h_path)
+            print(f"    Ingested {count} functions into DB")
+
+            # Ingest CXWnd.h member offsets if available
+            cxwnd_file = os.path.join(build_dir, 'CXWnd.h')
+            if os.path.exists(cxwnd_file):
+                mcount = db.ingest_struct_header(bid, cxwnd_file, 'CXWnd',
+                                                  start_marker='// @start: CXWnd Members',
+                                                  end_marker='// @end: CXWnd Members')
+                if mcount > 0:
+                    print(f"    Ingested {mcount} CXWnd member offsets")
+
+    print(f"\n{'='*60}")
+    print(f"Matched: {matched}/{len(build_dirs)}")
+    if unmatched:
+        print(f"Unmatched ({len(unmatched)}): {', '.join(unmatched)}")
+
+    print(f"\nDB stats:")
+    for k, v in db.stats().items():
+        print(f"  {k}: {v}")
+
+    db.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/re_pipeline/gap_analysis.py
+++ b/tools/re_pipeline/gap_analysis.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+gap_analysis.py - Place CXWnd fields using size/alignment constraints.
+
+For each build with ground truth:
+1. Identify fields that have HIGH accessor evidence
+2. Place those at their known offsets
+3. For remaining fields, check if size/alignment forces unique placement
+4. Add gap_analysis evidence records for forced placements
+
+Then cascade: if a field is resolved in build A and we have a BinDiff link
+to build B, translate the identifying function address.
+"""
+
+import os
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(__file__))
+from eq_xref_db import EQXrefDB
+
+# Type → (size, alignment) mapping for MSVC x64
+TYPE_SIZES = {
+    'bool': (1, 1),
+    'uint8_t': (1, 1),
+    'int': (4, 4),
+    'uint32_t': (4, 4),
+    'COLORREF': (4, 4),
+    'float': (4, 4),
+    'CXRect': (16, 4),
+    'CXSize': (8, 4),
+    'CXStr': (8, 8),
+    'int64_t': (8, 8),
+    'CXWnd*': (8, 8),
+    'CXWndDrawTemplate*': (8, 8),
+    'CLayoutStrategy*': (8, 8),
+    'CStaticTintedBlendAnimationTemplate*': (8, 8),
+    'CTextObjectInterface*': (8, 8),
+    'CTextureFont*': (8, 8),
+    'ControllerBase*': (8, 8),
+    'CTextureAnimation*': (8, 8),
+    'void*': (8, 8),
+    'ArrayClass2<uint32_t>': (32, 8),
+}
+
+# Fallback: any pointer type
+def get_type_size(field_type):
+    if field_type in TYPE_SIZES:
+        return TYPE_SIZES[field_type]
+    if field_type and '*' in field_type:
+        return (8, 8)
+    return None
+
+
+def run_gap_analysis(db, binary_id, build_date, class_name='CXWnd',
+                     struct_lo=0x030, struct_hi=0x268, dry_run=False):
+    """Run gap analysis for one build. Returns count of fields placed."""
+
+    # Get all member offsets for this build (ground truth)
+    all_members = db.get_all_members(class_name, binary_id)
+    if not all_members:
+        return 0
+
+    # Filter to instance members in struct range
+    members = [m for m in all_members if struct_lo <= m['offset_val'] < struct_hi]
+
+    # Get fields that already have HIGH evidence for this build
+    high_fields = set()
+    rows = db.conn.execute("""
+        SELECT DISTINCT sm.field_name
+        FROM evidence_records er
+        JOIN struct_members sm ON er.member_id = sm.id
+        WHERE er.binary_id = ? AND sm.class_name = ? AND er.confidence = 'HIGH'
+    """, (binary_id, class_name)).fetchall()
+    for r in rows:
+        high_fields.add(r['field_name'])
+
+    # Build offset map: offset → (field_name, field_type, size, align)
+    placed = {}  # offset → field_name (HIGH evidence fields)
+    unplaced = {}  # offset → (field_name, field_type, size, align)
+
+    for m in members:
+        ft = m['field_type']
+        ts = get_type_size(ft) if ft else None
+        if ts is None:
+            continue  # Skip fields with unknown type sizes
+
+        size, align = ts
+        off = m['offset_val']
+
+        if m['field_name'] in high_fields:
+            placed[off] = m['field_name']
+        else:
+            unplaced[off] = (m['field_name'], ft, size, align)
+
+    if not unplaced:
+        return 0
+
+    # Sort placed offsets to find gaps
+    placed_list = sorted(placed.items())  # [(offset, field_name), ...]
+
+    # For gap analysis: identify stretches where unplaced fields sit between placed fields
+    # A field is "forced" if it's the only unplaced field that fits in a gap
+    forced = []
+
+    # Build sorted list of ALL member offsets and their sizes
+    all_sorted = []
+    for m in members:
+        ft = m['field_type']
+        ts = get_type_size(ft) if ft else None
+        if ts:
+            all_sorted.append((m['offset_val'], m['field_name'], ts[0], ts[1],
+                              m['field_name'] in high_fields))
+    all_sorted.sort()
+
+    # Walk through consecutive unplaced fields between placed anchors
+    # Group unplaced fields that are between the same pair of placed fields
+    groups = []
+    current_group = []
+    last_placed = None
+
+    for off, fname, size, align, is_placed in all_sorted:
+        if is_placed:
+            if current_group:
+                groups.append((last_placed, current_group, off))
+                current_group = []
+            last_placed = off
+        else:
+            current_group.append((off, fname, size, align))
+
+    # Handle trailing unplaced after last placed
+    if current_group:
+        groups.append((last_placed, current_group, struct_hi))
+
+    # For each group: if only one field, it's forced by position
+    for before_off, group_fields, after_off in groups:
+        if len(group_fields) == 1:
+            off, fname, size, align = group_fields[0]
+            forced.append((off, fname, 'single field in gap'))
+            continue
+
+        # Multiple unplaced fields in this gap
+        # Check if each field's size+alignment makes it the only valid placement
+        # at its known offset (i.e., no other unplaced field could fit there)
+        for off, fname, size, align in group_fields:
+            # How many other unplaced fields in this group could fit at this offset?
+            candidates = []
+            for off2, fname2, size2, align2 in group_fields:
+                # Could fname2 sit at offset `off`?
+                # Check alignment: off must be aligned to align2
+                if align2 > 1 and off % align2 != 0:
+                    continue
+                # Check that it doesn't overlap next field
+                candidates.append(fname2)
+
+            if len(candidates) == 1 and candidates[0] == fname:
+                forced.append((off, fname, f'only field with align={align} size={size} fits at 0x{off:03x}'))
+
+    # Add evidence records for forced placements
+    added = 0
+    for off, fname, reason in forced:
+        if dry_run:
+            print(f"  FORCED: {fname} at 0x{off:03x} ({reason})")
+            continue
+
+        # Check if gap_analysis evidence already exists
+        existing = db.conn.execute("""
+            SELECT er.id FROM evidence_records er
+            JOIN struct_members sm ON er.member_id = sm.id
+            JOIN function_identities fi ON er.func_id = fi.id
+            WHERE er.binary_id = ? AND sm.class_name = ? AND sm.field_name = ?
+              AND fi.func_name = 'gap_analysis'
+        """, (binary_id, class_name, fname)).fetchone()
+
+        if not existing:
+            db.add_evidence(
+                binary_id=binary_id,
+                class_name=class_name,
+                field_name=fname,
+                func_name='gap_analysis',
+                func_addr=off,  # Use offset as pseudo-address
+                evidence_type='access',
+                decompile_line=f'gap_analysis: {reason}',
+                confidence='HIGH'
+            )
+            added += 1
+
+    return added
+
+
+def run_cascade(db, class_name='CXWnd', struct_lo=0x030, struct_hi=0x268):
+    """Cascade resolution: propagate identifications across builds via BinDiff.
+
+    If field F is identified in build A (HIGH evidence), and build A→B has
+    a BinDiff pair, check if the identifying function exists in B.
+    If so, add cascade evidence for F in B.
+    """
+    # Get all BinDiff pairs
+    pairs = db.conn.execute("""
+        SELECT DISTINCT old_binary, new_binary FROM bindiff_matches
+    """).fetchall()
+
+    added = 0
+    for pair in pairs:
+        old_bid, new_bid = pair['old_binary'], pair['new_binary']
+
+        # Get fields with HIGH evidence in old but not new
+        old_high = set(r['field_name'] for r in db.conn.execute("""
+            SELECT DISTINCT sm.field_name FROM evidence_records er
+            JOIN struct_members sm ON er.member_id = sm.id
+            WHERE er.binary_id = ? AND sm.class_name = ? AND er.confidence = 'HIGH'
+        """, (old_bid, class_name)).fetchall())
+
+        new_high = set(r['field_name'] for r in db.conn.execute("""
+            SELECT DISTINCT sm.field_name FROM evidence_records er
+            JOIN struct_members sm ON er.member_id = sm.id
+            WHERE er.binary_id = ? AND sm.class_name = ? AND er.confidence = 'HIGH'
+        """, (new_bid, class_name)).fetchall())
+
+        missing_in_new = old_high - new_high
+
+        if not missing_in_new:
+            continue
+
+        # For each missing field, find the identifying function in old
+        for fname in missing_in_new:
+            # Get the function that identifies this field in old build
+            func_rows = db.conn.execute("""
+                SELECT fi.func_name, fi.func_addr FROM evidence_records er
+                JOIN struct_members sm ON er.member_id = sm.id
+                JOIN function_identities fi ON er.func_id = fi.id
+                WHERE er.binary_id = ? AND sm.class_name = ? AND sm.field_name = ?
+                  AND er.confidence = 'HIGH'
+                LIMIT 1
+            """, (old_bid, class_name, fname)).fetchone()
+
+            if not func_rows:
+                continue
+
+            old_addr = func_rows['func_addr']
+            func_name = func_rows['func_name']
+
+            # Translate via BinDiff
+            new_addr = db.translate_address(old_bid, new_bid, old_addr)
+            if new_addr is None:
+                # Try reverse direction
+                new_addr = db.translate_address(new_bid, old_bid, old_addr)
+                if new_addr is not None:
+                    # This means old_addr exists in new→old direction, wrong way
+                    new_addr = None
+
+            if new_addr is None:
+                continue
+
+            # Check if cascade evidence already exists
+            existing = db.conn.execute("""
+                SELECT er.id FROM evidence_records er
+                JOIN struct_members sm ON er.member_id = sm.id
+                JOIN function_identities fi ON er.func_id = fi.id
+                WHERE er.binary_id = ? AND sm.class_name = ? AND sm.field_name = ?
+                  AND fi.func_name LIKE 'cascade_%'
+            """, (new_bid, class_name, fname)).fetchone()
+
+            if not existing:
+                db.add_evidence(
+                    binary_id=new_bid,
+                    class_name=class_name,
+                    field_name=fname,
+                    func_name=f'cascade_{func_name}',
+                    func_addr=new_addr,
+                    evidence_type='access',
+                    decompile_line=f'cascade from {func_name} via BinDiff',
+                    confidence='HIGH'
+                )
+                added += 1
+
+    return added
+
+
+def main():
+    db = EQXrefDB()
+
+    # Get all builds with ground truth
+    builds = db.conn.execute("""
+        SELECT id, build_date FROM binaries
+        WHERE server = 'live' AND eqgame_h IS NOT NULL
+        ORDER BY build_date
+    """).fetchall()
+
+    print(f"Running gap analysis on {len(builds)} builds...")
+
+    total_gap = 0
+    for b in builds:
+        bid, bdate = b['id'], b['build_date']
+        count = run_gap_analysis(db, bid, bdate)
+        if count > 0:
+            print(f"  {bdate}: {count} gap-forced fields added")
+            total_gap += count
+
+    print(f"\nGap analysis total: {total_gap} evidence records added")
+
+    # Run cascade resolution iteratively until no more progress
+    print(f"\nRunning cascade resolution...")
+    iteration = 0
+    while True:
+        iteration += 1
+        count = run_cascade(db)
+        if count == 0:
+            break
+        print(f"  Iteration {iteration}: {count} cascade records added")
+
+    # Final stats
+    print(f"\n{'='*60}")
+    print("Final coverage:")
+    rows = db.conn.execute("""
+        SELECT sm.field_name, COUNT(DISTINCT er.binary_id) as bc
+        FROM evidence_records er
+        JOIN struct_members sm ON er.member_id = sm.id
+        WHERE sm.class_name = 'CXWnd' AND er.confidence = 'HIGH'
+          AND EXISTS (
+            SELECT 1 FROM member_offsets mo
+            WHERE mo.member_id = sm.id AND mo.offset_val >= 0x030 AND mo.offset_val < 0x268
+          )
+        GROUP BY sm.field_name
+        ORDER BY bc DESC
+    """).fetchall()
+
+    by_count = defaultdict(list)
+    for r in rows:
+        by_count[r['bc']].append(r['field_name'])
+
+    total_fields = db.conn.execute("""
+        SELECT COUNT(DISTINCT sm.field_name) FROM member_offsets mo
+        JOIN struct_members sm ON mo.member_id = sm.id
+        WHERE sm.class_name = 'CXWnd' AND mo.offset_val >= 0x030 AND mo.offset_val < 0x268
+    """).fetchone()[0]
+
+    covered = len(rows)
+    at_5plus = sum(1 for r in rows if r['bc'] >= 5)
+
+    print(f"Total instance fields: {total_fields}")
+    print(f"Fields with any HIGH evidence: {covered}")
+    print(f"Fields with HIGH in 5+ builds: {at_5plus}")
+
+    # Show fields with < 5 builds
+    sparse = [(r['field_name'], r['bc']) for r in rows if r['bc'] < 5]
+    if sparse:
+        print(f"\nFields with < 5 builds HIGH evidence ({len(sparse)}):")
+        for fname, bc in sorted(sparse, key=lambda x: x[1]):
+            print(f"  {fname}: {bc}")
+
+    # Show fields with NO evidence
+    all_instance = set(r[0] for r in db.conn.execute("""
+        SELECT DISTINCT sm.field_name FROM member_offsets mo
+        JOIN struct_members sm ON mo.member_id = sm.id
+        WHERE sm.class_name = 'CXWnd' AND mo.offset_val >= 0x030 AND mo.offset_val < 0x268
+    """).fetchall())
+    no_evidence = all_instance - set(r['field_name'] for r in rows)
+    if no_evidence:
+        print(f"\nFields with NO HIGH evidence ({len(no_evidence)}):")
+        for fname in sorted(no_evidence):
+            print(f"  {fname}")
+
+    db.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/re_pipeline/ghidra/ExportViaReflection.java
+++ b/tools/re_pipeline/ghidra/ExportViaReflection.java
@@ -1,0 +1,52 @@
+// @category BinExport
+// Headless BinExport script for Ghidra.
+//
+// Works around OSGi classloader isolation by loading BinExport.jar
+// via URLClassLoader with Ghidra's own classloader as parent.
+//
+// Usage (headless):
+//   analyzeHeadless PROJECT_DIR PROJECT_NAME \
+//     -import binary.exe \
+//     -postScript ExportViaReflection.java /path/to/output.BinExport \
+//     -scriptPath /path/to/this/directory
+
+import ghidra.app.script.GhidraScript;
+import ghidra.app.util.exporter.Exporter;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class ExportViaReflection extends GhidraScript {
+    @Override
+    protected void run() throws Exception {
+        String[] args = getScriptArgs();
+        String outputPath = args.length > 0 ? args[0] : "/tmp/bindiff/output/export.BinExport";
+
+        File jarFile = new File("/opt/ghidra/Extensions/Ghidra/BinExport/lib/BinExport.jar");
+        if (!jarFile.exists()) {
+            printerr("BinExport.jar not found at: " + jarFile);
+            return;
+        }
+        println("Loading BinExport from: " + jarFile);
+
+        ClassLoader ghidraClassLoader = ghidra.app.util.exporter.Exporter.class.getClassLoader();
+        URLClassLoader loader = new URLClassLoader(
+            new URL[]{jarFile.toURI().toURL()},
+            ghidraClassLoader
+        );
+
+        Class<?> exporterClass = loader.loadClass("com.google.security.binexport.BinExportExporter");
+        Exporter exporter = (Exporter) exporterClass.getDeclaredConstructor().newInstance();
+        println("Exporter loaded: " + exporter.getName());
+
+        File outFile = new File(outputPath);
+        println("Exporting to: " + outputPath);
+        boolean result = exporter.export(outFile, currentProgram, currentProgram.getMemory(), monitor);
+
+        if (result) {
+            println("SUCCESS: " + outputPath + " (" + outFile.length() + " bytes)");
+        } else {
+            printerr("FAILED: export returned false");
+        }
+    }
+}

--- a/tools/re_pipeline/ghidra/ExtractReferences.java
+++ b/tools/re_pipeline/ghidra/ExtractReferences.java
@@ -11,9 +11,13 @@
 // Input: text file with "NAME 0xADDR" per line
 // Output: JSON with xref details
 //
-// Usage (headless):
-//   analyzeHeadless PROJECT_DIR PROJECT_NAME -process binary.exe \
-//     -noanalysis -postScript ExtractReferences.java input.txt output.json
+// Usage (headless) — either after -import (second -postScript after BinExport), or legacy:
+//   analyzeHeadless PROJECT_DIR PROJECT_NAME -import binary.exe \
+//     -postScript ExportViaReflection.java out.BinExport \
+//     -postScript ExtractReferences.java input.txt output.json \
+//     -scriptPath /path/to/ghidra
+//   analyzeHeadless PROJECT_DIR PROJECT_NAME -process binary.exe -noanalysis \
+//     -postScript ExtractReferences.java input.txt output.json
 
 import ghidra.app.script.GhidraScript;
 import ghidra.program.model.address.*;
@@ -57,7 +61,7 @@ public class ExtractReferences extends GhidraScript {
         AddressSpace space = currentProgram.getAddressFactory().getDefaultAddressSpace();
 
         StringBuilder json = new StringBuilder("{\n");
-        int totalXrefs = 0;
+        final int[] totalXrefs = {0};
 
         for (int i = 0; i < targets.size(); i++) {
             String name = targets.get(i)[0];
@@ -70,10 +74,8 @@ public class ExtractReferences extends GhidraScript {
             json.append(String.format("    \"address\": \"0x%X\",\n", targetLong));
             json.append("    \"xrefs\": [");
 
-            ReferenceIterator refs = refMgr.getReferencesTo(targetAddr);
-            boolean first = true;
-
-            for (Reference ref : refs) {
+            final boolean[] first = {true};
+            ReferenceManagerUtil.forEachReferenceTo(refMgr, targetAddr, ref -> {
                 Address fromAddr = ref.getFromAddress();
                 String refType = ref.getReferenceType().getName();
 
@@ -93,19 +95,21 @@ public class ExtractReferences extends GhidraScript {
                 }
                 refsFromJson.append("]");
 
-                if (!first) json.append(",");
+                if (!first[0]) {
+                    json.append(",");
+                }
                 json.append(String.format("\n      {\"from\": \"0x%X\", \"type\": \"%s\", " +
                         "\"mnemonic\": \"%s\", \"refs_from\": %s}",
                         fromAddr.getOffset(), refType, mnemonic, refsFromJson));
-                first = false;
-                totalXrefs++;
-            }
+                first[0] = false;
+                totalXrefs[0]++;
+            });
 
             json.append("\n    ]\n  }");
 
             if ((i + 1) % 50 == 0) {
                 println("  Progress: " + (i + 1) + "/" + targets.size() +
-                        " (" + totalXrefs + " xrefs)");
+                        " (" + totalXrefs[0] + " xrefs)");
             }
         }
 
@@ -115,7 +119,7 @@ public class ExtractReferences extends GhidraScript {
         writer.print(json.toString());
         writer.close();
 
-        println("ExtractReferences: " + totalXrefs + " xrefs for " + targets.size() +
+        println("ExtractReferences: " + totalXrefs[0] + " xrefs for " + targets.size() +
                 " targets -> " + outputPath);
     }
 }

--- a/tools/re_pipeline/ghidra/ExtractReferences.java
+++ b/tools/re_pipeline/ghidra/ExtractReferences.java
@@ -1,0 +1,121 @@
+// @category BinExport
+// For each target address, find all code locations that reference it,
+// AND extract what address each referencing instruction points to.
+//
+// This captures the complete xref picture:
+//   target_addr -> [(from_addr, referenced_addr, ref_type), ...]
+//
+// For the new binary, we use the from_addr (mapped via BinDiff) to find
+// the instruction, then read what address IT references -- that's our answer.
+//
+// Input: text file with "NAME 0xADDR" per line
+// Output: JSON with xref details
+//
+// Usage (headless):
+//   analyzeHeadless PROJECT_DIR PROJECT_NAME -process binary.exe \
+//     -noanalysis -postScript ExtractReferences.java input.txt output.json
+
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.address.*;
+import ghidra.program.model.symbol.*;
+import ghidra.program.model.listing.*;
+
+import java.io.*;
+import java.util.*;
+
+public class ExtractReferences extends GhidraScript {
+    @Override
+    protected void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length < 2) {
+            printerr("Usage: ExtractReferences.java <input.txt> <output.json>");
+            return;
+        }
+
+        String inputPath = args[0];
+        String outputPath = args[1];
+
+        println("ExtractReferences: reading from " + inputPath);
+
+        // Read targets: "NAME 0xADDR" per line
+        List<String[]> targets = new ArrayList<>();
+        BufferedReader reader = new BufferedReader(new FileReader(inputPath));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            line = line.trim();
+            if (line.isEmpty() || line.startsWith("#")) continue;
+            String[] parts = line.split("\\s+");
+            if (parts.length >= 2) {
+                targets.add(new String[]{parts[0], parts[1]});
+            }
+        }
+        reader.close();
+        println("  Loaded " + targets.size() + " targets");
+
+        ReferenceManager refMgr = currentProgram.getReferenceManager();
+        Listing listing = currentProgram.getListing();
+        AddressSpace space = currentProgram.getAddressFactory().getDefaultAddressSpace();
+
+        StringBuilder json = new StringBuilder("{\n");
+        int totalXrefs = 0;
+
+        for (int i = 0; i < targets.size(); i++) {
+            String name = targets.get(i)[0];
+            String addrStr = targets.get(i)[1];
+            long targetLong = Long.parseUnsignedLong(addrStr.replace("0x", "").replace("0X", ""), 16);
+            Address targetAddr = space.getAddress(targetLong);
+
+            if (i > 0) json.append(",\n");
+            json.append(String.format("  \"%s\": {\n", name));
+            json.append(String.format("    \"address\": \"0x%X\",\n", targetLong));
+            json.append("    \"xrefs\": [");
+
+            ReferenceIterator refs = refMgr.getReferencesTo(targetAddr);
+            boolean first = true;
+
+            for (Reference ref : refs) {
+                Address fromAddr = ref.getFromAddress();
+                String refType = ref.getReferenceType().getName();
+
+                // Get the instruction at the from address
+                Instruction instr = listing.getInstructionAt(fromAddr);
+                String mnemonic = instr != null ? instr.getMnemonicString() : "unknown";
+                String operands = instr != null ? instr.toString().substring(mnemonic.length()).trim() : "";
+
+                // Get all references FROM this instruction (what addresses it touches)
+                Reference[] fromRefs = instr != null ? instr.getReferencesFrom() : new Reference[0];
+                StringBuilder refsFromJson = new StringBuilder("[");
+                boolean firstFrom = true;
+                for (Reference fromRef : fromRefs) {
+                    if (!firstFrom) refsFromJson.append(", ");
+                    refsFromJson.append(String.format("\"0x%X\"", fromRef.getToAddress().getOffset()));
+                    firstFrom = false;
+                }
+                refsFromJson.append("]");
+
+                if (!first) json.append(",");
+                json.append(String.format("\n      {\"from\": \"0x%X\", \"type\": \"%s\", " +
+                        "\"mnemonic\": \"%s\", \"refs_from\": %s}",
+                        fromAddr.getOffset(), refType, mnemonic, refsFromJson));
+                first = false;
+                totalXrefs++;
+            }
+
+            json.append("\n    ]\n  }");
+
+            if ((i + 1) % 50 == 0) {
+                println("  Progress: " + (i + 1) + "/" + targets.size() +
+                        " (" + totalXrefs + " xrefs)");
+            }
+        }
+
+        json.append("\n}\n");
+
+        PrintWriter writer = new PrintWriter(new FileWriter(outputPath));
+        writer.print(json.toString());
+        writer.close();
+
+        println("ExtractReferences: " + totalXrefs + " xrefs for " + targets.size() +
+                " targets -> " + outputPath);
+    }
+}

--- a/tools/re_pipeline/ghidra/ExtractXrefs.java
+++ b/tools/re_pipeline/ghidra/ExtractXrefs.java
@@ -1,0 +1,92 @@
+// @category BinExport
+// Extract cross-references for a list of target addresses.
+//
+// Input: text file with one hex address per line (e.g., 0x140DDB608)
+// Output: JSON file mapping each address to its xref locations
+//
+// Usage (headless):
+//   analyzeHeadless PROJECT_DIR PROJECT_NAME -process binary.exe \
+//     -noanalysis -postScript ExtractXrefs.java input_addrs.txt output_xrefs.json
+
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.address.*;
+import ghidra.program.model.symbol.*;
+import ghidra.program.model.listing.*;
+
+import java.io.*;
+import java.util.*;
+
+public class ExtractXrefs extends GhidraScript {
+    @Override
+    protected void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args.length < 2) {
+            printerr("Usage: ExtractXrefs.java <input_addrs.txt> <output_xrefs.json>");
+            return;
+        }
+
+        String inputPath = args[0];
+        String outputPath = args[1];
+
+        println("ExtractXrefs: reading addresses from " + inputPath);
+
+        // Read target addresses
+        List<Long> targets = new ArrayList<>();
+        BufferedReader reader = new BufferedReader(new FileReader(inputPath));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            line = line.trim();
+            if (line.startsWith("0x") || line.startsWith("0X")) {
+                targets.add(Long.parseUnsignedLong(line.substring(2), 16));
+            }
+        }
+        reader.close();
+        println("  Loaded " + targets.size() + " target addresses");
+
+        // Get reference manager
+        ReferenceManager refMgr = currentProgram.getReferenceManager();
+        AddressFactory addrFactory = currentProgram.getAddressFactory();
+        AddressSpace defaultSpace = addrFactory.getDefaultAddressSpace();
+
+        // For each target, find all xrefs TO it
+        StringBuilder json = new StringBuilder("{\n");
+        int found = 0;
+        int total = 0;
+
+        for (int i = 0; i < targets.size(); i++) {
+            long targetAddr = targets.get(i);
+            Address addr = defaultSpace.getAddress(targetAddr);
+
+            Reference[] refs = refMgr.getReferencesTo(addr);
+
+            if (i > 0) json.append(",\n");
+            json.append(String.format("  \"0x%X\": [", targetAddr));
+
+            boolean first = true;
+            for (Reference ref : refs) {
+                Address fromAddr = ref.getFromAddress();
+                if (!first) json.append(", ");
+                json.append(String.format("\"0x%X\"", fromAddr.getOffset()));
+                first = false;
+                found++;
+            }
+            json.append("]");
+            total++;
+
+            if ((i + 1) % 100 == 0) {
+                println("  Progress: " + (i + 1) + "/" + targets.size() +
+                        " (" + found + " xrefs found)");
+            }
+        }
+
+        json.append("\n}\n");
+
+        // Write output
+        PrintWriter writer = new PrintWriter(new FileWriter(outputPath));
+        writer.print(json.toString());
+        writer.close();
+
+        println("ExtractXrefs: wrote " + found + " xrefs for " + total +
+                " addresses to " + outputPath);
+    }
+}

--- a/tools/re_pipeline/ghidra/ExtractXrefs.java
+++ b/tools/re_pipeline/ghidra/ExtractXrefs.java
@@ -50,32 +50,32 @@ public class ExtractXrefs extends GhidraScript {
 
         // For each target, find all xrefs TO it
         StringBuilder json = new StringBuilder("{\n");
-        int found = 0;
+        final int[] found = {0};
         int total = 0;
 
         for (int i = 0; i < targets.size(); i++) {
             long targetAddr = targets.get(i);
             Address addr = defaultSpace.getAddress(targetAddr);
 
-            Reference[] refs = refMgr.getReferencesTo(addr);
-
             if (i > 0) json.append(",\n");
             json.append(String.format("  \"0x%X\": [", targetAddr));
 
-            boolean first = true;
-            for (Reference ref : refs) {
+            final boolean[] first = {true};
+            ReferenceManagerUtil.forEachReferenceTo(refMgr, addr, ref -> {
                 Address fromAddr = ref.getFromAddress();
-                if (!first) json.append(", ");
+                if (!first[0]) {
+                    json.append(", ");
+                }
                 json.append(String.format("\"0x%X\"", fromAddr.getOffset()));
-                first = false;
-                found++;
-            }
+                first[0] = false;
+                found[0]++;
+            });
             json.append("]");
             total++;
 
             if ((i + 1) % 100 == 0) {
                 println("  Progress: " + (i + 1) + "/" + targets.size() +
-                        " (" + found + " xrefs found)");
+                        " (" + found[0] + " xrefs found)");
             }
         }
 
@@ -86,7 +86,7 @@ public class ExtractXrefs extends GhidraScript {
         writer.print(json.toString());
         writer.close();
 
-        println("ExtractXrefs: wrote " + found + " xrefs for " + total +
+        println("ExtractXrefs: wrote " + found[0] + " xrefs for " + total +
                 " addresses to " + outputPath);
     }
 }

--- a/tools/re_pipeline/ghidra/ReferenceManagerUtil.java
+++ b/tools/re_pipeline/ghidra/ReferenceManagerUtil.java
@@ -1,0 +1,101 @@
+// Shared helper for Ghidra scripts — not a standalone script.
+// getReferencesTo(Address) return type differs across Ghidra versions (Reference[] vs ReferenceIterator, etc.).
+
+import ghidra.program.model.address.Address;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.symbol.ReferenceIterator;
+import ghidra.program.model.symbol.ReferenceManager;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+
+/**
+ * Invokes ReferenceManager.getReferencesTo(Address) via reflection and dispatches on the runtime
+ * return type so scripts compile against any Ghidra install in this toolchain.
+ */
+public final class ReferenceManagerUtil {
+
+    private static volatile Method getReferencesToMethod;
+
+    @FunctionalInterface
+    public interface ReferenceToVisitor {
+        void accept(Reference ref) throws Exception;
+    }
+
+    private ReferenceManagerUtil() {
+    }
+
+    private static Method resolveGetReferencesToMethod() throws NoSuchMethodException {
+        if (getReferencesToMethod == null) {
+            synchronized (ReferenceManagerUtil.class) {
+                if (getReferencesToMethod == null) {
+                    getReferencesToMethod =
+                            ReferenceManager.class.getMethod("getReferencesTo", Address.class);
+                }
+            }
+        }
+        return getReferencesToMethod;
+    }
+
+    /**
+     * Invokes getReferencesTo and visits each Reference in iteration order.
+     */
+    public static void forEachReferenceTo(ReferenceManager refMgr, Address addr,
+            ReferenceToVisitor visitor) throws Exception {
+        Object result;
+        try {
+            result = resolveGetReferencesToMethod().invoke(refMgr, addr);
+        } catch (InvocationTargetException e) {
+            Throwable c = e.getCause();
+            if (c instanceof Exception) {
+                throw (Exception) c;
+            }
+            throw new RuntimeException(e.getCause());
+        } catch (IllegalAccessException | NoSuchMethodException e) {
+            throw new RuntimeException("getReferencesTo reflection failed", e);
+        }
+
+        if (result == null) {
+            return;
+        }
+
+        if (result instanceof Reference[]) {
+            for (Reference r : (Reference[]) result) {
+                visitor.accept(r);
+            }
+            return;
+        }
+
+        if (result instanceof ReferenceIterator) {
+            ReferenceIterator ri = (ReferenceIterator) result;
+            while (ri.hasNext()) {
+                visitor.accept(ri.next());
+            }
+            return;
+        }
+
+        if (result instanceof Iterator) {
+            Iterator<?> it = (Iterator<?>) result;
+            while (it.hasNext()) {
+                Object o = it.next();
+                if (o instanceof Reference) {
+                    visitor.accept((Reference) o);
+                }
+            }
+            return;
+        }
+
+        if (result instanceof Iterable) {
+            for (Object o : (Iterable<?>) result) {
+                if (o instanceof Reference) {
+                    visitor.accept((Reference) o);
+                }
+            }
+            return;
+        }
+
+        throw new IllegalStateException(
+                "getReferencesTo returned unsupported type: " + result.getClass().getName());
+    }
+}

--- a/tools/re_pipeline/parse_vtable_decompilations.py
+++ b/tools/re_pipeline/parse_vtable_decompilations.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+Parse batch-decompiled vtable functions and extract field access patterns.
+
+Input: /tmp/cxwnd_all_decompiled.txt (from rz-ghidra batch)
+       /tmp/cxwnd_vtable_addrs.txt (vtable index -> function address mapping)
+
+Output: Field offset map with confidence levels.
+
+This script does NOT reference any answer key.
+"""
+
+import re
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+from vtable_accessor_scanner import parse_decompilation, type_to_size
+
+# Known vtable function names from CXWnd::VirtualFunctionTable
+# Corrected vtable-to-name mapping from CXWnd::VirtualFunctionTable struct
+# Source: our own CXWnd.h VirtualFunctionTable (corrected index alignment)
+VTABLE_NAMES = {
+    0: "IsValid", 1: "Destructor", 2: "GetWndClassName",
+    3: "DrawNC", 4: "Draw", 5: "PostDraw", 6: "DrawCursor",
+    7: "DrawChildItem", 8: "DrawCaret", 9: "DrawBackground",
+    10: "DrawTooltip", 11: "DrawTooltipAtPoint", 12: "GetMinimizedRect",
+    13: "DrawTitleBar", 14: "SetZLayer", 15: "GetCursorToDisplay",
+    16: "HandleLButtonDown", 17: "HandleLButtonUp", 18: "HandleLButtonHeld",
+    19: "HandleLButtonUpAfterHeld", 20: "HandleRButtonDown",
+    21: "HandleRButtonUp", 22: "HandleRButtonHeld",
+    23: "HandleRButtonUpAfterHeld", 24: "HandleWheelButtonDown",
+    25: "HandleWheelButtonUp", 26: "HandleMouseMove",
+    27: "HandleWheelMove", 28: "HandleKeyboardMsg",
+    29: "HandleMouseLeave", 30: "OnDragDrop", 31: "GetDragDropCursor",
+    32: "QueryDropOK", 33: "OnClickStick", 34: "GetClickStickCursor",
+    35: "QueryClickStickDropOK", 36: "WndNotification",
+    37: "OnWndNotification", 38: "Activate", 39: "Deactivate",
+    40: "OnShow", 41: "OnMove", 42: "OnResize",
+    43: "OnBeginMoveOrResize", 44: "OnCompleteMoveOrResize",
+    45: "OnMinimizeBox", 46: "OnMaximizeBox", 47: "OnTileBox",
+    48: "OnTile", 49: "OnSetFocus", 50: "OnKillFocus",
+    51: "OnProcessFrame", 52: "OnVScroll", 53: "OnHScroll",
+    54: "OnBroughtToTop", 55: "OnActivate", 56: "Show",
+    57: "AboutToShow", 58: "AboutToHide", 59: "RequestDockInfo",
+    60: "GetTooltip", 61: "ClickThroughMenuItemTriggered",
+    62: "SetLocked", 63: "HitTest", 64: "GetHitTestRect",
+    65: "GetInnerRect", 66: "GetClientRect", 67: "GetClientClipRect",
+    68: "GetMinSize", 69: "GetMaxSize", 70: "GetUntileSize",
+    71: "IsPointTransparent", 72: "ShouldProcessChildrenFrames",
+    73: "ShouldProcessControllerFrame",
+    74: "SetDrawTemplate", 75: "SetBGType", 76: "SetBGColor",
+    77: "UpdateGeometry", 78: "Move", 79: "Minimize",
+    80: "SetWindowText", 81: "SetTooltip",
+    82: "Center", 83: "CenterVertically", 84: "CenterHorizontally",
+    85: "Top", 86: "Bottom", 87: "Right", 88: "Left",
+    89: "MoveToCursor", 90: "GetChildWndAt", 91: "GetSidlPiece",
+    92: "GetWindowName", 93: "SetVScrollPos", 94: "SetHScrollPos",
+    95: "AutoSetVScrollPos", 96: "AutoSetHScrollPos",
+    97: "SetAttributesFromSidl", 98: "OnReloadSidl",
+    99: "HasActivatedFirstTimeAlert", 100: "SetHasActivatedFirstTimeAlert",
+    101: "GetMinClientSize", 102: "GetMaxClientSize",
+    103: "GetActiveEditWnd", 104: "UpdateLayout",
+}
+
+
+def load_vtable_mapping(vtable_file):
+    """Load vtable index -> function address mapping."""
+    mapping = {}
+    with open(vtable_file) as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) == 2:
+                idx = int(parts[0])
+                addr = parts[1].strip().lower()
+                mapping[addr] = idx
+    return mapping
+
+
+def load_decompilations(decompile_file):
+    """Load batch decompilation output, split by function."""
+    functions = {}
+    current_addr = None
+    current_code = []
+
+    with open(decompile_file) as f:
+        for line in f:
+            if line.startswith("@@@ FUNC "):
+                if current_addr and current_code:
+                    functions[current_addr] = "\n".join(current_code)
+                current_addr = line.split()[2].strip().lower()
+                current_code = []
+            else:
+                current_code.append(line.rstrip())
+
+    if current_addr and current_code:
+        functions[current_addr] = "\n".join(current_code)
+
+    return functions
+
+
+def load_named_decompilations(decompile_file):
+    """Load decompilations with function names (@@@ FUNC addr name @@@)."""
+    functions = {}
+    current_key = None
+    current_code = []
+
+    with open(decompile_file) as f:
+        for line in f:
+            if line.startswith("@@@ FUNC "):
+                if current_key and current_code:
+                    functions[current_key] = "\n".join(current_code)
+                parts = line.split()
+                addr = parts[2].strip().lower()
+                name = parts[3] if len(parts) > 3 else "unknown"
+                current_key = (addr, name.rstrip(" @"))
+                current_code = []
+            else:
+                current_code.append(line.rstrip())
+
+    if current_key and current_code:
+        functions[current_key] = "\n".join(current_code)
+
+    return functions
+
+
+def main():
+    vtable_file = "/tmp/cxwnd_vtable_addrs.txt"
+    decompile_file = "/tmp/cxwnd_all_decompiled.txt"
+    exports_file = "/tmp/cxwnd_exports_decompiled.txt"
+
+    if not os.path.exists(decompile_file):
+        print("Waiting for decompilation to complete...")
+        return
+
+    vtable_map = load_vtable_mapping(vtable_file)
+    functions = load_decompilations(decompile_file)
+
+    # Also load named export decompilations if available
+    export_functions = {}
+    if os.path.exists(exports_file):
+        export_functions = load_named_decompilations(exports_file)
+        print(f"Loaded {len(export_functions)} named export functions")
+
+    print(f"Loaded {len(functions)} vtable functions")
+    print(f"Vtable mapping: {len(vtable_map)} entries")
+
+    # Process each function
+    all_findings = []
+    for addr, code in functions.items():
+        vtable_idx = vtable_map.get(addr)
+        func_name = VTABLE_NAMES.get(vtable_idx, f"vfunc_{vtable_idx}") if vtable_idx is not None else "unknown"
+
+        findings = parse_decompilation(code, func_name)
+
+        # For setter/getter naming: only name the field that's directly written/read
+        # A setter that writes param2 to ONE offset is reliable even if the function
+        # reads other offsets as side effects (e.g. SetZLayer writes 0x244 then calls manager)
+        setters = [f for f in findings if f["type"] == "setter" and 0x030 <= f["offset"] < 0x268]
+        getters = [f for f in findings if f["type"] == "getter" and 0x030 <= f["offset"] < 0x268]
+
+        for f in findings:
+            f["func_addr"] = addr
+            f["func_name"] = func_name
+            f["vtable_idx"] = vtable_idx
+
+            # Name from Set functions: only the setter target (param2 write)
+            if func_name.startswith("Set") and f["type"] == "setter" and len(setters) == 1:
+                f["probable_field"] = func_name[3:]
+                f["confidence"] = "HIGH"
+            # Name from Get functions: only the getter return value
+            elif func_name.startswith("Get") and f["type"] == "getter" and len(getters) == 1:
+                f["probable_field"] = func_name[3:]
+                f["confidence"] = "HIGH"
+
+        all_findings.extend(findings)
+
+    # Process named export functions
+    for (addr, name), code in export_functions.items():
+        findings = parse_decompilation(code, name)
+
+        setters_e = [f for f in findings if f["type"] == "setter" and 0x030 <= f["offset"] < 0x268]
+        getters_e = [f for f in findings if f["type"] == "getter" and 0x030 <= f["offset"] < 0x268]
+
+        for f in findings:
+            f["func_addr"] = addr
+            f["func_name"] = name
+            f["vtable_idx"] = None
+
+            if name.startswith("Set") and f["type"] == "setter" and len(setters_e) == 1:
+                f["probable_field"] = name[3:]
+                f["confidence"] = "HIGH"
+            elif name.startswith("Get") and f["type"] == "getter" and len(getters_e) == 1:
+                f["probable_field"] = name[3:]
+                f["confidence"] = "HIGH"
+
+        all_findings.extend(findings)
+
+    # Merge by offset
+    by_offset = {}
+    for f in all_findings:
+        off = f["offset"]
+        if off < 0x030 or off >= 0x300:  # filter to CXWnd member range
+            continue
+        if off not in by_offset:
+            by_offset[off] = []
+        by_offset[off].append(f)
+
+    # Print results
+    print(f"\n{'='*80}")
+    print(f"FIELD ACCESS MAP (from vtable function analysis)")
+    print(f"{'='*80}")
+
+    for off in sorted(by_offset.keys()):
+        findings = by_offset[off]
+        # Pick best finding
+        best = max(findings, key=lambda f: (
+            {"HIGH": 3, "MED": 2, "LOW": 1}.get(f["confidence"], 0),
+            1 if f.get("probable_field") else 0
+        ))
+
+        name = best.get("probable_field", "?")
+        conf = best["confidence"]
+        access = best["type"]
+        size = best["size"]
+        func = best["func_name"]
+
+        marker = "*" if conf == "HIGH" else " "
+        print(f"{marker} 0x{off:03X} ({size}B) = {name:30s} [{conf:4s}] via {func} ({access})")
+
+    # Summary
+    high = sum(1 for findings in by_offset.values()
+               if any(f["confidence"] == "HIGH" for f in findings))
+    med = sum(1 for findings in by_offset.values()
+              if all(f["confidence"] != "HIGH" for f in findings)
+              and any(f["confidence"] == "MED" for f in findings))
+    print(f"\nTotal offsets found: {len(by_offset)}")
+    print(f"  HIGH confidence: {high}")
+    print(f"  MED confidence: {med}")
+    print(f"  Other: {len(by_offset) - high - med}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/re_pipeline/patch_day_pipeline.sh
+++ b/tools/re_pipeline/patch_day_pipeline.sh
@@ -109,14 +109,29 @@ sed -i "s/MAXMEM=2G/MAXMEM=$GHIDRA_HEAP/" "$HEADLESS"
 sed -i "s|\"\${SCRIPT_DIR}\"|\"$GHIDRA_DIR/support\"|" "$HEADLESS"
 chmod +x "$HEADLESS"
 
-# ── Step 1: Ghidra Headless Analysis + BinExport ─────────────────────
-echo "[Step 1/4] Ghidra analysis + BinExport (parallel, ~20 min)..."
+# Xref targets for ExtractReferences (must exist before Ghidra; xref runs in same JVM as old binary BinExport)
+python3 -c "
+import re
+with open('$OLD_HEADER') as f:
+    with open('$WORK_DIR/xref_targets.txt', 'w') as out:
+        for line in f:
+            m = re.match(r'#define\s+(\w+)_x\s+(0x[0-9a-fA-F]+)', line.strip())
+            if m:
+                out.write(f'{m.group(1)} {m.group(2)}\n')
+"
+
+# ── Step 1/4: Ghidra headless: BinExport + xref extraction (old) in one JVM; BinExport (new) ──
+echo "[Step 1/4] Ghidra analysis + BinExport + xref extraction (parallel, ~20 min)..."
+echo "  Old binary: BinExport then ExtractReferences (same session). Log: $WORK_DIR/old_ghidra.log"
+echo "  New binary: BinExport only. Log: $WORK_DIR/new_ghidra.log"
 START_TIME=$SECONDS
 
-# Launch both in parallel
+# Old binary: two postScripts — BinExport, then ExtractReferences (avoids reopening project; NotOwnerException on second open).
+# Redirect only (no tee) so $OLD_PID is analyzeHeadless and wait returns its real exit code.
 "$HEADLESS" "$WORK_DIR/old_project" OldEQ \
     -import "$OLD_BINARY" \
     -postScript "$BINEXPORT_SCRIPT" "$WORK_DIR/output/old.BinExport" \
+    -postScript ExtractReferences.java "$WORK_DIR/xref_targets.txt" "$WORK_DIR/old_xrefs.json" \
     -scriptPath "$(dirname "$BINEXPORT_SCRIPT")" \
     > "$WORK_DIR/old_ghidra.log" 2>&1 &
 OLD_PID=$!
@@ -128,35 +143,46 @@ OLD_PID=$!
     > "$WORK_DIR/new_ghidra.log" 2>&1 &
 NEW_PID=$!
 
-echo "  Old binary analysis PID: $OLD_PID"
+echo "  Old binary analysis PID: $OLD_PID (analyzeHeadless; log $WORK_DIR/old_ghidra.log)"
 echo "  New binary analysis PID: $NEW_PID"
 echo "  Waiting for both to complete..."
 
-# Monitor progress
 FAILED=0
 wait $OLD_PID || FAILED=1
 if [[ $FAILED -eq 1 ]]; then
-    echo "  ERROR: Old binary analysis failed. Check $WORK_DIR/old_ghidra.log"
+    echo "  ERROR: Old binary analysis failed. Last lines of $WORK_DIR/old_ghidra.log:"
+    tail -20 "$WORK_DIR/old_ghidra.log" 2>/dev/null || true
     exit 1
 fi
 echo "  Old binary: done ($(( SECONDS - START_TIME ))s)"
 
 wait $NEW_PID || FAILED=1
 if [[ $FAILED -eq 1 ]]; then
-    echo "  ERROR: New binary analysis failed. Check $WORK_DIR/new_ghidra.log"
+    echo "  ERROR: New binary analysis failed. Last lines of $WORK_DIR/new_ghidra.log:"
+    tail -20 "$WORK_DIR/new_ghidra.log" 2>/dev/null || true
     exit 1
 fi
 echo "  New binary: done ($(( SECONDS - START_TIME ))s)"
 
-# Verify exports exist
+# Do not validate *.gpr size: Ghidra often leaves .gpr empty/minimal; real project data lives under *.rep.
+# Step 1 success is gated by BinExport + old_xrefs.json below.
+
 [[ -f "$WORK_DIR/output/old.BinExport" ]] || { echo "ERROR: old BinExport not created"; exit 1; }
 [[ -f "$WORK_DIR/output/new.BinExport" ]] || { echo "ERROR: new BinExport not created"; exit 1; }
+
+[[ -f "$WORK_DIR/old_xrefs.json" ]] || { echo "ERROR: old_xrefs.json not created (ExtractReferences). Check $WORK_DIR/old_ghidra.log"; exit 1; }
+OLD_XREF_SIZE=$(stat -c%s "$WORK_DIR/old_xrefs.json")
+if [[ "$OLD_XREF_SIZE" -eq 0 ]]; then
+    echo "ERROR: old_xrefs.json is empty. Check $WORK_DIR/old_ghidra.log"
+    exit 1
+fi
 
 OLD_SIZE=$(stat -c%s "$WORK_DIR/output/old.BinExport")
 NEW_SIZE=$(stat -c%s "$WORK_DIR/output/new.BinExport")
 echo "  Exports: old=${OLD_SIZE} bytes, new=${NEW_SIZE} bytes"
+echo "  Xrefs:   old_xrefs.json=${OLD_XREF_SIZE} bytes"
 
-# ── Step 2: BinDiff ──────────────────────────────────────────────────
+# ── Step 2/4: BinDiff ────────────────────────────────────────────────
 echo ""
 echo "[Step 2/4] BinDiff function matching..."
 DIFF_START=$SECONDS
@@ -175,35 +201,9 @@ echo "  $MATCHED"
 echo "  $SIMILARITY"
 echo "  Completed in $(( SECONDS - DIFF_START ))s"
 
-# ── Step 3: Extract Cross-References ─────────────────────────────────
+# ── Step 3/4: Address translation ─────────────────────────────────────
 echo ""
-echo "[Step 3/5] Extracting cross-references from old binary..."
-XREF_START=$SECONDS
-XREF_SCRIPT="$SCRIPT_DIR/ghidra/ExtractReferences.java"
-
-# Generate target address list
-python3 -c "
-import re
-with open('$OLD_HEADER') as f:
-    with open('$WORK_DIR/xref_targets.txt', 'w') as out:
-        for line in f:
-            m = re.match(r'#define\s+(\w+)_x\s+(0x[0-9a-fA-F]+)', line.strip())
-            if m:
-                out.write(f'{m.group(1)} {m.group(2)}\n')
-"
-
-"$HEADLESS" "$WORK_DIR/old_project" OldEQ \
-    -process eqgame.exe -noanalysis \
-    -scriptPath "$(dirname "$XREF_SCRIPT")" \
-    -postScript ExtractReferences.java "$WORK_DIR/xref_targets.txt" "$WORK_DIR/old_xrefs.json" \
-    > "$WORK_DIR/old_xref.log" 2>&1
-
-[[ -f "$WORK_DIR/old_xrefs.json" ]] || { echo "ERROR: xref extraction failed. Check $WORK_DIR/old_xref.log"; exit 1; }
-echo "  Xrefs extracted in $(( SECONDS - XREF_START ))s"
-
-# ── Step 4: Address Translation ──────────────────────────────────────
-echo ""
-echo "[Step 4/5] Translating eqgame.h addresses..."
+echo "[Step 3/4] Translating eqgame.h addresses..."
 
 MATCHER_ARGS=(
     --old-binary "$OLD_BINARY"
@@ -219,7 +219,7 @@ MATCHER_ARGS=(
 
 python3 "$MATCHER_SCRIPT" "${MATCHER_ARGS[@]}"
 
-# ── Step 5: Output ───────────────────────────────────────────────────
+# ── Step 4/4: Results ────────────────────────────────────────────────
 echo ""
 echo "[Step 4/4] Results"
 echo "============================================================"

--- a/tools/re_pipeline/patch_day_pipeline.sh
+++ b/tools/re_pipeline/patch_day_pipeline.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+#
+# patch_day_pipeline.sh -- Automated eqgame.h generation for EQ patch day
+#
+# Takes old and new eqgame.exe binaries + old eqgame.h (known baseline)
+# and produces new eqgame.h with updated addresses.
+#
+# Requirements:
+#   - Ghidra 12.x with BinExport extension at /opt/ghidra/
+#   - BinDiff 8 (bindiff command)
+#   - rizin with rz-ghidra
+#   - Python 3.10+
+#   - JDK 21 (for BinExport compilation)
+#
+# Usage:
+#   ./patch_day_pipeline.sh \
+#     --old-binary /path/to/old/eqgame.exe \
+#     --new-binary /path/to/new/eqgame.exe \
+#     --old-header /path/to/old/eqgame.h \
+#     [--answer-key /path/to/new/eqgame.h] \
+#     [--work-dir /tmp/patch_day] \
+#     [--workers 60] \
+#     [--ghidra-heap 16G]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Defaults
+WORK_DIR="/tmp/patch_day_$(date +%Y%m%d_%H%M%S)"
+WORKERS=60
+GHIDRA_HEAP="16G"
+GHIDRA_DIR="/opt/ghidra"
+ANSWER_KEY=""
+
+usage() {
+    echo "Usage: $0 --old-binary OLD --new-binary NEW --old-header HEADER [options]"
+    echo ""
+    echo "Required:"
+    echo "  --old-binary    Path to old eqgame.exe"
+    echo "  --new-binary    Path to new eqgame.exe"
+    echo "  --old-header    Path to old eqgame.h (known baseline)"
+    echo ""
+    echo "Optional:"
+    echo "  --answer-key    Path to new eqgame.h for scoring (validation only)"
+    echo "  --work-dir      Working directory (default: /tmp/patch_day_TIMESTAMP)"
+    echo "  --workers       Parallel workers for sub-function matching (default: 60)"
+    echo "  --ghidra-heap   Ghidra JVM heap size (default: 16G)"
+    echo "  --ghidra-dir    Ghidra installation directory (default: /opt/ghidra)"
+    exit 1
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --old-binary)   OLD_BINARY="$2"; shift 2 ;;
+        --new-binary)   NEW_BINARY="$2"; shift 2 ;;
+        --old-header)   OLD_HEADER="$2"; shift 2 ;;
+        --answer-key)   ANSWER_KEY="$2"; shift 2 ;;
+        --work-dir)     WORK_DIR="$2"; shift 2 ;;
+        --workers)      WORKERS="$2"; shift 2 ;;
+        --ghidra-heap)  GHIDRA_HEAP="$2"; shift 2 ;;
+        --ghidra-dir)   GHIDRA_DIR="$2"; shift 2 ;;
+        -h|--help)      usage ;;
+        *)              echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# Validate required args
+[[ -z "${OLD_BINARY:-}" ]] && { echo "ERROR: --old-binary required"; usage; }
+[[ -z "${NEW_BINARY:-}" ]] && { echo "ERROR: --new-binary required"; usage; }
+[[ -z "${OLD_HEADER:-}" ]] && { echo "ERROR: --old-header required"; usage; }
+[[ -f "$OLD_BINARY" ]] || { echo "ERROR: old binary not found: $OLD_BINARY"; exit 1; }
+[[ -f "$NEW_BINARY" ]] || { echo "ERROR: new binary not found: $NEW_BINARY"; exit 1; }
+[[ -f "$OLD_HEADER" ]] || { echo "ERROR: old header not found: $OLD_HEADER"; exit 1; }
+
+# Validate tools
+command -v bindiff >/dev/null || { echo "ERROR: bindiff not found. Install: yay -S bindiff"; exit 1; }
+command -v rizin >/dev/null || { echo "ERROR: rizin not found"; exit 1; }
+[[ -d "$GHIDRA_DIR" ]] || { echo "ERROR: Ghidra not found at $GHIDRA_DIR"; exit 1; }
+[[ -f "$GHIDRA_DIR/Extensions/Ghidra/BinExport/lib/BinExport.jar" ]] || {
+    echo "ERROR: BinExport extension not installed in Ghidra"
+    echo "Build from source: see tools/re_pipeline/README.md"
+    exit 1
+}
+
+# Setup
+mkdir -p "$WORK_DIR"/{old_project,new_project,output}
+BINEXPORT_SCRIPT="$SCRIPT_DIR/ghidra/ExportViaReflection.java"
+MATCHER_SCRIPT="$SCRIPT_DIR/eqgame_h_generator.py"
+
+echo "============================================================"
+echo "EQ Patch Day Pipeline"
+echo "============================================================"
+echo "Old binary:  $OLD_BINARY"
+echo "New binary:  $NEW_BINARY"
+echo "Old header:  $OLD_HEADER"
+echo "Work dir:    $WORK_DIR"
+echo "Workers:     $WORKERS"
+echo "Ghidra heap: $GHIDRA_HEAP"
+[[ -n "$ANSWER_KEY" ]] && echo "Answer key:  $ANSWER_KEY (scoring only)"
+echo "============================================================"
+echo ""
+
+# Create modified analyzeHeadless with increased heap
+HEADLESS="$WORK_DIR/analyzeHeadless"
+cp "$GHIDRA_DIR/support/analyzeHeadless" "$HEADLESS"
+sed -i "s/MAXMEM=2G/MAXMEM=$GHIDRA_HEAP/" "$HEADLESS"
+sed -i "s|\"\${SCRIPT_DIR}\"|\"$GHIDRA_DIR/support\"|" "$HEADLESS"
+chmod +x "$HEADLESS"
+
+# ── Step 1: Ghidra Headless Analysis + BinExport ─────────────────────
+echo "[Step 1/4] Ghidra analysis + BinExport (parallel, ~20 min)..."
+START_TIME=$SECONDS
+
+# Launch both in parallel
+"$HEADLESS" "$WORK_DIR/old_project" OldEQ \
+    -import "$OLD_BINARY" \
+    -postScript "$BINEXPORT_SCRIPT" "$WORK_DIR/output/old.BinExport" \
+    -scriptPath "$(dirname "$BINEXPORT_SCRIPT")" \
+    > "$WORK_DIR/old_ghidra.log" 2>&1 &
+OLD_PID=$!
+
+"$HEADLESS" "$WORK_DIR/new_project" NewEQ \
+    -import "$NEW_BINARY" \
+    -postScript "$BINEXPORT_SCRIPT" "$WORK_DIR/output/new.BinExport" \
+    -scriptPath "$(dirname "$BINEXPORT_SCRIPT")" \
+    > "$WORK_DIR/new_ghidra.log" 2>&1 &
+NEW_PID=$!
+
+echo "  Old binary analysis PID: $OLD_PID"
+echo "  New binary analysis PID: $NEW_PID"
+echo "  Waiting for both to complete..."
+
+# Monitor progress
+FAILED=0
+wait $OLD_PID || FAILED=1
+if [[ $FAILED -eq 1 ]]; then
+    echo "  ERROR: Old binary analysis failed. Check $WORK_DIR/old_ghidra.log"
+    exit 1
+fi
+echo "  Old binary: done ($(( SECONDS - START_TIME ))s)"
+
+wait $NEW_PID || FAILED=1
+if [[ $FAILED -eq 1 ]]; then
+    echo "  ERROR: New binary analysis failed. Check $WORK_DIR/new_ghidra.log"
+    exit 1
+fi
+echo "  New binary: done ($(( SECONDS - START_TIME ))s)"
+
+# Verify exports exist
+[[ -f "$WORK_DIR/output/old.BinExport" ]] || { echo "ERROR: old BinExport not created"; exit 1; }
+[[ -f "$WORK_DIR/output/new.BinExport" ]] || { echo "ERROR: new BinExport not created"; exit 1; }
+
+OLD_SIZE=$(stat -c%s "$WORK_DIR/output/old.BinExport")
+NEW_SIZE=$(stat -c%s "$WORK_DIR/output/new.BinExport")
+echo "  Exports: old=${OLD_SIZE} bytes, new=${NEW_SIZE} bytes"
+
+# ── Step 2: BinDiff ──────────────────────────────────────────────────
+echo ""
+echo "[Step 2/4] BinDiff function matching..."
+DIFF_START=$SECONDS
+
+bindiff "$WORK_DIR/output/old.BinExport" "$WORK_DIR/output/new.BinExport" \
+    --output_dir="$WORK_DIR/output/" \
+    > "$WORK_DIR/bindiff.log" 2>&1
+
+BINDIFF_DB=$(find "$WORK_DIR/output/" -name "*.BinDiff" -type f | head -1)
+[[ -f "$BINDIFF_DB" ]] || { echo "ERROR: BinDiff output not found"; exit 1; }
+
+# Extract summary from log
+MATCHED=$(grep "^matched:" "$WORK_DIR/bindiff.log" 2>/dev/null || echo "unknown")
+SIMILARITY=$(grep "^Similarity:" "$WORK_DIR/bindiff.log" 2>/dev/null || echo "unknown")
+echo "  $MATCHED"
+echo "  $SIMILARITY"
+echo "  Completed in $(( SECONDS - DIFF_START ))s"
+
+# ── Step 3: Extract Cross-References ─────────────────────────────────
+echo ""
+echo "[Step 3/5] Extracting cross-references from old binary..."
+XREF_START=$SECONDS
+XREF_SCRIPT="$SCRIPT_DIR/ghidra/ExtractReferences.java"
+
+# Generate target address list
+python3 -c "
+import re
+with open('$OLD_HEADER') as f:
+    with open('$WORK_DIR/xref_targets.txt', 'w') as out:
+        for line in f:
+            m = re.match(r'#define\s+(\w+)_x\s+(0x[0-9a-fA-F]+)', line.strip())
+            if m:
+                out.write(f'{m.group(1)} {m.group(2)}\n')
+"
+
+"$HEADLESS" "$WORK_DIR/old_project" OldEQ \
+    -process eqgame.exe -noanalysis \
+    -scriptPath "$(dirname "$XREF_SCRIPT")" \
+    -postScript ExtractReferences.java "$WORK_DIR/xref_targets.txt" "$WORK_DIR/old_xrefs.json" \
+    > "$WORK_DIR/old_xref.log" 2>&1
+
+[[ -f "$WORK_DIR/old_xrefs.json" ]] || { echo "ERROR: xref extraction failed. Check $WORK_DIR/old_xref.log"; exit 1; }
+echo "  Xrefs extracted in $(( SECONDS - XREF_START ))s"
+
+# ── Step 4: Address Translation ──────────────────────────────────────
+echo ""
+echo "[Step 4/5] Translating eqgame.h addresses..."
+
+MATCHER_ARGS=(
+    --old-binary "$OLD_BINARY"
+    --new-binary "$NEW_BINARY"
+    --old-header "$OLD_HEADER"
+    --bindiff-db "$BINDIFF_DB"
+    --old-xrefs "$WORK_DIR/old_xrefs.json"
+    --workers "$WORKERS"
+    --output "$WORK_DIR/results.json"
+    --generate "$WORK_DIR/eqgame_new.h"
+)
+[[ -n "$ANSWER_KEY" ]] && MATCHER_ARGS+=(--new-header "$ANSWER_KEY")
+
+python3 "$MATCHER_SCRIPT" "${MATCHER_ARGS[@]}"
+
+# ── Step 5: Output ───────────────────────────────────────────────────
+echo ""
+echo "[Step 4/4] Results"
+echo "============================================================"
+echo "Generated header:  $WORK_DIR/eqgame_new.h"
+echo "Full results:      $WORK_DIR/results.json"
+echo "BinDiff database:  $BINDIFF_DB"
+echo "Total time:        $(( SECONDS - START_TIME ))s"
+echo "============================================================"
+
+if [[ -f "$WORK_DIR/eqgame_new.h" ]]; then
+    ENTRY_COUNT=$(grep -c "#define.*_x.*0x" "$WORK_DIR/eqgame_new.h")
+    echo "Entries in generated header: $ENTRY_COUNT"
+fi

--- a/tools/re_pipeline/populate_evidence.py
+++ b/tools/re_pipeline/populate_evidence.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+populate_evidence.py - Run accessor scanning against historical builds
+and populate evidence_records in the cross-reference database.
+
+For each build:
+1. Decompile CXWnd/CSidlScreenWnd accessor functions via rizin
+2. Parse setter/getter patterns to identify which function accesses which offset
+3. Cross-reference with ground truth to name the offset
+4. Store as evidence records in eq_xref.db
+
+Usage:
+    python3 populate_evidence.py [--build 2025-08-26] [--workers 32]
+
+    Without --build, runs against all builds in the database.
+"""
+
+import re
+import os
+import sys
+import json
+import subprocess
+import argparse
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+from eq_xref_db import EQXrefDB
+from vtable_accessor_scanner import parse_decompilation
+
+BASE_DIR = os.path.join(os.path.dirname(__file__), '..', '..')
+CACHE_DIR = os.path.join(BASE_DIR, 'data', 'evidence_cache')
+
+
+def decompile_function(binary_path, addr_hex, func_name):
+    """Decompile a single function via rz-ghidra."""
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"af @ {addr_hex}; pdg @ {addr_hex}",
+             binary_path],
+            capture_output=True, text=True, timeout=30
+        )
+        code = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        if len(code) > 20 and "ERROR" not in code:
+            return (func_name, addr_hex, code)
+    except (subprocess.TimeoutExpired, Exception) as e:
+        pass
+    return (func_name, addr_hex, None)
+
+
+def scan_build(db, binary_id, build_date, binary_path, workers=32):
+    """Scan one build for accessor evidence."""
+
+    print(f"\n{'='*60}")
+    print(f"Scanning {build_date}: {binary_path}")
+    print(f"{'='*60}")
+
+    # Get all CXWnd/CSidlScreenWnd function addresses for this build
+    funcs = {}
+    for row in db.conn.execute("""
+        SELECT func_name, func_addr FROM function_identities
+        WHERE binary_id = ? AND (
+            func_name LIKE 'CXWnd__%' OR
+            func_name LIKE 'CSidlScreenWnd__%' OR
+            func_name LIKE 'CXWndManager__%'
+        )
+    """, (binary_id,)).fetchall():
+        funcs[row['func_name']] = f"0x{row['func_addr']:x}"
+
+    if not funcs:
+        print(f"  No CXWnd functions found for {build_date}")
+        return 0
+
+    print(f"  {len(funcs)} functions to scan")
+
+    # Check cache
+    cache_dir = Path(CACHE_DIR) / build_date
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # Decompile (with caching)
+    decompilations = {}
+    to_decompile = {}
+
+    for func_name, addr in funcs.items():
+        cache_file = cache_dir / f"{func_name}.txt"
+        if cache_file.exists():
+            code = cache_file.read_text()
+            if len(code) > 20:
+                decompilations[func_name] = code
+                continue
+        to_decompile[func_name] = addr
+
+    if decompilations:
+        print(f"  {len(decompilations)} cached, {len(to_decompile)} to decompile")
+
+    if to_decompile:
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(decompile_function, binary_path, addr, name): name
+                for name, addr in to_decompile.items()
+            }
+            done = 0
+            for future in as_completed(futures):
+                name, addr, code = future.result()
+                done += 1
+                if code:
+                    decompilations[name] = code
+                    (cache_dir / f"{name}.txt").write_text(code)
+                if done % 20 == 0:
+                    print(f"  Decompiled {done}/{len(to_decompile)}...")
+
+    print(f"  Total decompiled: {len(decompilations)}")
+
+    # Get ground truth offsets for this build
+    ground_truth = {}  # offset -> field_name
+    for row in db.conn.execute("""
+        SELECT sm.field_name, sm.class_name, mo.offset_val
+        FROM member_offsets mo
+        JOIN struct_members sm ON mo.member_id = sm.id
+        WHERE mo.binary_id = ? AND mo.confidence = 'GROUND_TRUTH'
+    """, (binary_id,)).fetchall():
+        ground_truth[row['offset_val']] = (row['class_name'], row['field_name'])
+
+    # Parse decompilations for accessor patterns
+    evidence_count = 0
+
+    for func_name, code in decompilations.items():
+        findings = parse_decompilation(code, func_name)
+
+        for finding in findings:
+            offset = finding['offset']
+            ftype = finding['type']  # 'setter', 'getter', etc
+
+            if offset not in ground_truth:
+                continue
+
+            class_name, field_name = ground_truth[offset]
+            func_addr = int(funcs.get(func_name, '0'), 16)
+
+            # Map finding type to evidence type
+            evidence_type = ftype if ftype in ('setter', 'getter') else 'access'
+
+            # Get a representative line from the decompilation
+            decompile_line = None
+            offset_hex = f"0x{offset:x}"
+            for line in code.split('\n'):
+                if offset_hex in line.lower() or f"+{offset}" in line:
+                    decompile_line = line.strip()[:200]
+                    break
+
+            db.add_evidence(
+                binary_id=binary_id,
+                class_name=class_name,
+                field_name=field_name,
+                func_name=func_name,
+                func_addr=func_addr,
+                evidence_type=evidence_type,
+                decompile_line=decompile_line,
+                confidence='HIGH' if ftype in ('setter', 'getter') else 'MED'
+            )
+            evidence_count += 1
+
+    print(f"  Evidence records added: {evidence_count}")
+    return evidence_count
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Populate evidence records")
+    parser.add_argument("--build", help="Specific build date (default: all)")
+    parser.add_argument("--workers", type=int, default=32, help="Parallel decompile workers")
+    args = parser.parse_args()
+
+    db = EQXrefDB()
+
+    if args.build:
+        builds = [args.build]
+    else:
+        builds = [r['build_date'] for r in db.list_binaries() if r['server'] == 'live']
+
+    total_evidence = 0
+
+    for build_date in sorted(builds):
+        bid = db.get_binary_id(build_date)
+        if not bid:
+            print(f"Build {build_date} not in database, skipping")
+            continue
+
+        row = db.conn.execute(
+            "SELECT binary_path FROM binaries WHERE id = ?", (bid,)).fetchone()
+        binary_path = row['binary_path']
+
+        if not os.path.exists(binary_path):
+            print(f"Binary not found: {binary_path}, skipping")
+            continue
+
+        # Check if evidence already exists for this build
+        existing = db.conn.execute(
+            "SELECT COUNT(*) FROM evidence_records WHERE binary_id = ?", (bid,)).fetchone()[0]
+        if existing > 0:
+            print(f"  {build_date}: {existing} evidence records already exist, skipping")
+            continue
+
+        count = scan_build(db, bid, build_date, binary_path, args.workers)
+        total_evidence += count
+
+    # Summary
+    print(f"\n{'='*60}")
+    print(f"Total evidence records added: {total_evidence}")
+
+    stats = db.stats()
+    print(f"\nDatabase stats:")
+    for k, v in stats.items():
+        print(f"  {k}: {v}")
+
+    # Show top identifying functions
+    print(f"\nTop identifying functions for CXWnd (appear in most builds):")
+    rows = db.conn.execute("""
+        SELECT fi.func_name, sm.field_name, er.evidence_type,
+               COUNT(DISTINCT b.id) as build_count
+        FROM evidence_records er
+        JOIN struct_members sm ON er.member_id = sm.id
+        JOIN function_identities fi ON er.func_id = fi.id
+        JOIN binaries b ON er.binary_id = b.id
+        WHERE sm.class_name = 'CXWnd' AND er.confidence = 'HIGH'
+        GROUP BY fi.func_name, sm.field_name, er.evidence_type
+        HAVING build_count >= 5
+        ORDER BY build_count DESC, fi.func_name
+        LIMIT 30
+    """).fetchall()
+
+    for row in rows:
+        print(f"  {row['func_name']:45s} -> {row['field_name']:25s} "
+              f"({row['evidence_type']}) {row['build_count']}/7 builds")
+
+    db.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/re_pipeline/populate_xref_db.py
+++ b/tools/re_pipeline/populate_xref_db.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+populate_xref_db.py - Backfill the cross-reference database from historical builds.
+
+Ingests:
+1. All live builds from eq-builds/live/ (binary + eqgame.h ground truth)
+2. CXWnd.h member offsets from eqlib git history for each build
+3. BinDiff results from pipeline runs
+"""
+
+import os
+import sys
+import re
+import subprocess
+import sqlite3
+
+sys.path.insert(0, os.path.dirname(__file__))
+from eq_xref_db import EQXrefDB
+
+BASE_DIR = os.path.join(os.path.dirname(__file__), '..', '..')
+BUILDS_DIR = os.path.join(BASE_DIR, 'eq-builds')
+EQLIB_DIR = os.path.join(BASE_DIR, 'eqlib-history')
+PIPELINE_RUNS = os.path.join(BASE_DIR, 'data', 'pipeline_runs')
+
+
+# Map build dates to eqlib commits that have the matching CXWnd.h
+# These are the commits where brainiac updated for each live patch
+EQLIB_COMMITS = {
+    '2025-08-26': '3c352ecc',
+    '2025-09-16': 'e0a59681',
+    '2025-10-14': '9cce0eb7',
+    '2025-11-17': '28d686cf',
+    '2025-12-08': '19cbcefe',
+    '2026-01-22': 'bd4a4ab2',
+    '2026-02-10': '90403708',
+}
+
+# Old eqlib had CXWnd.h at root, newer ones at include/eqlib/game/
+CXWND_PATHS = [
+    'include/eqlib/game/CXWnd.h',
+    'CXWnd.h',
+]
+
+
+def find_cxwnd_at_commit(commit):
+    """Extract CXWnd.h content from an eqlib git commit."""
+    for path in CXWND_PATHS:
+        result = subprocess.run(
+            ['git', '-C', EQLIB_DIR, 'show', f'{commit}:{path}'],
+            capture_output=True, text=True)
+        if result.returncode == 0 and 'CXWnd' in result.stdout:
+            return result.stdout
+    return None
+
+
+def ingest_cxwnd_members(db, binary_id, header_content):
+    """Parse CXWnd member offsets from header content string."""
+    # find the member block between @start and @end markers
+    start = header_content.find('@start: CXWnd Members')
+    end = header_content.find('@end: CXWnd Members')
+
+    if start < 0 or end < 0:
+        # older format might not have markers, search for the member block
+        start = header_content.find('// CXWnd Members')
+        if start < 0:
+            start = 0
+        end = len(header_content)
+
+    section = header_content[start:end]
+
+    member_re = re.compile(
+        r'/\*0x([0-9a-fA-F]+)\*/\s+(\S+(?:\s*\*)?)\s+(\w+)\s*;')
+
+    count = 0
+    for m in member_re.finditer(section):
+        offset = int(m.group(1), 16)
+        field_type = m.group(2).strip()
+        field_name = m.group(3)
+
+        if field_name.startswith('Pad') or field_name.startswith('__'):
+            continue
+
+        member_id = db.ensure_member('CXWnd', field_name, field_type)
+        db.conn.execute(
+            """INSERT OR REPLACE INTO member_offsets
+               (binary_id, member_id, offset_val, confidence, source)
+               VALUES (?, ?, ?, 'GROUND_TRUTH', 'eqlib_git')""",
+            (binary_id, member_id, offset))
+        count += 1
+
+    # Also grab CSidlScreenWnd members
+    sidl_start = header_content.find('CSidlScreenWnd')
+    if sidl_start > 0:
+        sidl_section = header_content[sidl_start:]
+        for m in member_re.finditer(sidl_section):
+            offset = int(m.group(1), 16)
+            field_type = m.group(2).strip()
+            field_name = m.group(3)
+            if field_name.startswith('Pad'):
+                continue
+            member_id = db.ensure_member('CSidlScreenWnd', field_name, field_type)
+            db.conn.execute(
+                """INSERT OR REPLACE INTO member_offsets
+                   (binary_id, member_id, offset_val, confidence, source)
+                   VALUES (?, ?, ?, 'GROUND_TRUTH', 'eqlib_git')""",
+                (binary_id, member_id, offset))
+            count += 1
+
+    db.conn.commit()
+    return count
+
+
+def ingest_bindiff_results(db):
+    """Import BinDiff results from preserved pipeline runs."""
+    if not os.path.exists(PIPELINE_RUNS):
+        print("  No pipeline runs directory found, skipping BinDiff ingestion")
+        return
+
+    for dirname in sorted(os.listdir(PIPELINE_RUNS)):
+        # parse dates from dirname like "patch_day_2025-09-16_to_2025-10-14"
+        date_match = re.search(r'(\d{4}-\d{2}-\d{2})_to_(\d{4}-\d{2}-\d{2})', dirname)
+        if not date_match:
+            # try the old format "patch_day_20260330_104236"
+            continue
+
+        old_date = date_match.group(1)
+        new_date = date_match.group(2)
+
+        old_id = db.get_binary_id(old_date)
+        new_id = db.get_binary_id(new_date)
+        if not old_id or not new_id:
+            continue
+
+        # find BinDiff DB
+        output_dir = os.path.join(PIPELINE_RUNS, dirname, 'output')
+        bindiff_files = [f for f in os.listdir(output_dir)
+                        if f.endswith('.BinDiff')] if os.path.exists(output_dir) else []
+
+        if bindiff_files:
+            bd_path = os.path.join(output_dir, bindiff_files[0])
+            count = db.ingest_bindiff(old_id, new_id, bd_path)
+            print(f"  BinDiff {old_date} -> {new_date}: {count} function matches")
+
+
+def main():
+    db = EQXrefDB()
+    print(f"Database: {db.db_path}\n")
+
+    # Step 1: Register all live builds and ingest eqgame.h
+    print("=== Registering builds and ingesting eqgame.h ===")
+    live_dir = os.path.join(BUILDS_DIR, 'live')
+    for build_date in sorted(os.listdir(live_dir)):
+        build_path = os.path.join(live_dir, build_date)
+        if not os.path.isdir(build_path):
+            continue
+
+        exe_path = os.path.join(build_path, 'eqgame.exe')
+        h_path = os.path.join(build_path, 'eqgame.h')
+
+        if not os.path.exists(exe_path):
+            continue
+
+        bid = db.add_binary(build_date, exe_path,
+                           h_path if os.path.exists(h_path) else None,
+                           server='live')
+
+        if os.path.exists(h_path):
+            func_count = db.ingest_eqgame_h(bid, h_path)
+            print(f"  {build_date}: {func_count} functions from eqgame.h")
+
+    # Also register test builds
+    test_dir = os.path.join(BUILDS_DIR, 'test')
+    if os.path.exists(test_dir):
+        for build_date in sorted(os.listdir(test_dir)):
+            build_path = os.path.join(test_dir, build_date)
+            if not os.path.isdir(build_path):
+                continue
+            exe_path = os.path.join(build_path, 'eqgame.exe')
+            if os.path.exists(exe_path):
+                db.add_binary(build_date, exe_path, server='test')
+                print(f"  {build_date} (test): registered")
+
+    # Step 2: Ingest CXWnd member offsets from eqlib git history
+    print("\n=== Ingesting CXWnd member offsets from eqlib git ===")
+    for build_date, commit in sorted(EQLIB_COMMITS.items()):
+        bid = db.get_binary_id(build_date)
+        if not bid:
+            print(f"  {build_date}: no binary registered, skipping")
+            continue
+
+        content = find_cxwnd_at_commit(commit)
+        if content:
+            count = ingest_cxwnd_members(db, bid, content)
+            print(f"  {build_date} (commit {commit[:8]}): {count} struct members")
+        else:
+            print(f"  {build_date}: CXWnd.h not found at commit {commit[:8]}")
+
+    # Step 3: Ingest BinDiff results
+    print("\n=== Ingesting BinDiff results ===")
+    ingest_bindiff_results(db)
+
+    # Summary
+    print("\n=== Database stats ===")
+    stats = db.stats()
+    for k, v in stats.items():
+        print(f"  {k}: {v}")
+
+    # Show member offset history for a sample field
+    print("\n=== Sample: CXWnd::pController history ===")
+    history = db.get_member_history('CXWnd', 'pController')
+    for h in history:
+        print(f"  {h['build_date']}  0x{h['offset_val']:03x}  {h['confidence']}")
+
+    db.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/re_pipeline/requirements.txt
+++ b/tools/re_pipeline/requirements.txt
@@ -1,0 +1,9 @@
+# EQ RE Pipeline - Python Dependencies
+#
+# All scripts use Python 3.10+ stdlib only. No pip packages required.
+#
+# External tool dependencies (not Python):
+#   - rizin (with rz-ghidra plugin) - disassembly
+#   - Ghidra 12.x (with BinExport extension) - binary analysis
+#   - BinDiff 8 - function matching
+#   - JDK 21 - required by Ghidra headless

--- a/tools/re_pipeline/scan_full_binary.py
+++ b/tools/re_pipeline/scan_full_binary.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Scan ALL BinDiff-matched functions (not just CXWnd range) for CXWnd member accessors.
+Filters to small functions first (< 50 bytes) to find pure getters/setters efficiently.
+"""
+import os, re, subprocess, sqlite3, sys, struct
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+sys.path.insert(0, os.path.dirname(__file__))
+from eq_xref_db import EQXrefDB
+
+BASE = os.path.join(os.path.dirname(__file__), '..', '..')
+PIPELINE_DIR = os.path.join(BASE, 'data', 'pipeline_runs')
+CACHE_DIR = os.path.join(BASE, 'data', 'full_scan_cache')
+
+
+def get_small_functions(exe_path, addrs, max_size=64):
+    """Filter to functions that are small (likely pure accessors).
+    Uses rizin to get function size, batched for efficiency."""
+    small = []
+    # Batch: analyze and get size for each function
+    # This is faster than individual calls
+    for addr in addrs:
+        try:
+            result = subprocess.run(
+                ["rizin", "-a", "x86", "-b", "64", "-q",
+                 "-c", f"af @ 0x{addr:x}; afi @ 0x{addr:x} ~size",
+                 exe_path], capture_output=True, text=True, timeout=5)
+            text = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+            m = re.search(r'size:\s*(\d+)', text)
+            if m and int(m.group(1)) <= max_size:
+                small.append((addr, int(m.group(1))))
+        except:
+            pass
+    return small
+
+
+def scan_func(exe, addr):
+    """Disassemble one function, extract CXWnd-range offsets."""
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"af @ 0x{addr:x}; pdf @ 0x{addr:x}",
+             exe], capture_output=True, text=True, timeout=10)
+        text = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        offsets = set()
+        for m in re.finditer(r'\[(?:rcx|rbx|rdi|rsi|r14|r15)\s*\+\s*0x([0-9a-fA-F]+)\]', text):
+            off = int(m.group(1), 16)
+            if 0x030 <= off < 0x268:
+                offsets.add(off)
+        return (addr, offsets)
+    except:
+        return (addr, set())
+
+
+def main():
+    db = EQXrefDB()
+    build_date = sys.argv[1] if len(sys.argv) > 1 else '2026-02-10'
+    bid = db.get_binary_id(build_date)
+    row = db.conn.execute("SELECT binary_path FROM binaries WHERE id = ?", (bid,)).fetchone()
+    exe = row['binary_path']
+
+    # Get all BinDiff addresses for this build
+    known_addrs = set(r['func_addr'] for r in db.conn.execute(
+        "SELECT func_addr FROM function_identities WHERE binary_id = ?", (bid,)))
+
+    all_addrs = set()
+    for dirname in os.listdir(PIPELINE_DIR):
+        if build_date not in dirname:
+            continue
+        bd_dir = os.path.join(PIPELINE_DIR, dirname, 'output')
+        if not os.path.exists(bd_dir):
+            continue
+        for f in os.listdir(bd_dir):
+            if f.endswith('.BinDiff'):
+                bd = sqlite3.connect(os.path.join(bd_dir, f))
+                for r in bd.execute("SELECT address1, address2 FROM function WHERE similarity > 0.5"):
+                    all_addrs.add(r[0])
+                    all_addrs.add(r[1])
+                bd.close()
+
+    # EXCLUDE CXWnd range (already scanned) and known eqgame.h functions
+    outside_cxwnd = [a for a in all_addrs
+                     if not (0x1405B0000 <= a <= 0x14060FFFF)
+                     and a not in known_addrs
+                     and 0x140001000 <= a <= 0x140900000]  # .text range only
+
+    print(f"Build {build_date}: {len(outside_cxwnd)} functions outside CXWnd range")
+
+    # Check cache
+    cache_dir = os.path.join(CACHE_DIR, build_date)
+    os.makedirs(cache_dir, exist_ok=True)
+    cache_file = os.path.join(cache_dir, 'full_scan_results.txt')
+
+    if os.path.exists(cache_file):
+        hits = defaultdict(list)
+        with open(cache_file) as f:
+            for line in f:
+                parts = line.strip().split('\t')
+                if len(parts) == 3:
+                    hits[int(parts[0])].append((int(parts[1]), int(parts[2])))
+        print(f"Loaded {sum(len(v) for v in hits.values())} cached results")
+    else:
+        # Scan all with parallel workers -- rizin is fast for small functions
+        print(f"Scanning {len(outside_cxwnd)} functions with 48 workers...")
+        hits = defaultdict(list)
+
+        with ProcessPoolExecutor(max_workers=48) as executor:
+            futures = {executor.submit(scan_func, exe, addr): addr for addr in outside_cxwnd}
+            done = 0
+            for future in as_completed(futures):
+                addr, offsets = future.result()
+                done += 1
+                if offsets and len(offsets) <= 3:
+                    for off in offsets:
+                        hits[off].append((addr, len(offsets)))
+                if done % 500 == 0:
+                    print(f"  {done}/{len(outside_cxwnd)}...")
+
+        # Cache
+        with open(cache_file, 'w') as f:
+            for off, entries in sorted(hits.items()):
+                for addr, n in entries:
+                    f.write(f"{off}\t{addr}\t{n}\n")
+
+        print(f"Found {sum(len(v) for v in hits.values())} accessor hits")
+
+    # Map offsets to fields
+    offset_to_field = {}
+    for r in db.conn.execute("""
+        SELECT sm.field_name, mo.offset_val FROM member_offsets mo
+        JOIN struct_members sm ON mo.member_id = sm.id
+        WHERE mo.binary_id = ? AND sm.class_name = 'CXWnd'
+    """, (bid,)):
+        offset_to_field[r['offset_val']] = r['field_name']
+
+    # Report and add to database
+    print(f"\nAccessors from outside CXWnd code range:")
+    added = 0
+    for off in sorted(hits.keys()):
+        field = offset_to_field.get(off)
+        if not field:
+            continue
+        entries = hits[off]
+        pure = [e for e in entries if e[1] == 1]
+        dual = [e for e in entries if e[1] == 2]
+        triple = [e for e in entries if e[1] == 3]
+
+        parts = []
+        if pure: parts.append(f"{len(pure)} pure")
+        if dual: parts.append(f"{len(dual)} dual")
+        if triple: parts.append(f"{len(triple)} triple")
+
+        if pure or dual:
+            print(f"  0x{off:03x} {field:30s}: {', '.join(parts)}")
+
+        # Add best evidence
+        if pure:
+            addr, n = pure[0]
+            conf = 'HIGH'
+        elif dual:
+            addr, n = dual[0]
+            conf = 'MED'
+        else:
+            continue
+
+        db.add_evidence(
+            binary_id=bid,
+            class_name='CXWnd',
+            field_name=field,
+            func_name=f"unlisted_wide_0x{addr:x}",
+            func_addr=addr,
+            evidence_type='getter' if n == 1 else 'access',
+            decompile_line=f"non-CXWnd-range function at 0x{addr:x}, {n} offset(s)",
+            confidence=conf
+        )
+        added += 1
+
+    print(f"\nAdded {added} evidence records")
+
+    # Final count
+    rows = db.conn.execute("""
+        SELECT sm.field_name, COUNT(DISTINCT b.id) as bc
+        FROM evidence_records er
+        JOIN struct_members sm ON er.member_id = sm.id
+        JOIN binaries b ON er.binary_id = b.id
+        WHERE sm.class_name = 'CXWnd' AND er.confidence = 'HIGH'
+        GROUP BY sm.field_name
+        HAVING bc >= 5
+        ORDER BY bc DESC
+    """).fetchall()
+    print(f"\nHIGH confidence fields (5+ builds): {len(rows)}")
+
+    remaining = set(offset_to_field.values()) - set(r['field_name'] for r in rows)
+    if remaining:
+        print(f"Still not HIGH ({len(remaining)}): {', '.join(sorted(remaining))}")
+
+    db.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/re_pipeline/scan_unlisted_accessors.py
+++ b/tools/re_pipeline/scan_unlisted_accessors.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Scan non-eqgame.h functions in the CXWnd code range for focused accessors."""
+import os, re, subprocess, sqlite3, sys
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+sys.path.insert(0, os.path.dirname(__file__))
+from eq_xref_db import EQXrefDB
+
+def scan_func(exe, addr):
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"af @ 0x{addr:x}; pdf @ 0x{addr:x}",
+             exe], capture_output=True, text=True, timeout=10)
+        text = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        offsets = set()
+        for m in re.finditer(r'\[(?:rcx|rbx|rdi|rsi|r14|r15)\s*\+\s*0x([0-9a-fA-F]+)\]', text):
+            off = int(m.group(1), 16)
+            if 0x030 <= off < 0x268:
+                offsets.add(off)
+        return (addr, offsets)
+    except:
+        return (addr, set())
+
+def main():
+    db = EQXrefDB()
+    build_date = sys.argv[1] if len(sys.argv) > 1 else '2026-02-10'
+    bid = db.get_binary_id(build_date)
+
+    build_row = db.conn.execute("SELECT binary_path FROM binaries WHERE id = ?", (bid,)).fetchone()
+    EXE = build_row['binary_path']
+
+    known_addrs = set(r['func_addr'] for r in db.conn.execute(
+        "SELECT func_addr FROM function_identities WHERE binary_id = ?", (bid,)))
+
+    # Get all function addresses from BinDiff for this build
+    pipeline_dir = "/mnt/DEV/reverse-engineering/MQ-RE/data/pipeline_runs"
+    # Find a BinDiff DB where this build is the "new" binary
+    all_addrs = set()
+    for dirname in os.listdir(pipeline_dir):
+        if build_date not in dirname:
+            continue
+        bd_dir = os.path.join(pipeline_dir, dirname, 'output')
+        if not os.path.exists(bd_dir):
+            continue
+        for f in os.listdir(bd_dir):
+            if f.endswith('.BinDiff'):
+                bd_conn = sqlite3.connect(os.path.join(bd_dir, f))
+                for r in bd_conn.execute("SELECT address1, address2 FROM function WHERE similarity > 0.5"):
+                    all_addrs.add(r[0])
+                    all_addrs.add(r[1])
+                bd_conn.close()
+
+    cxwnd_range = [a for a in all_addrs if 0x1405B0000 <= a <= 0x14060FFFF and a not in known_addrs]
+    print(f"Scanning {len(cxwnd_range)} non-eqgame.h CXWnd-range functions for {build_date}...")
+
+    all_offsets = {}
+    for r in db.conn.execute("""
+        SELECT sm.field_name, mo.offset_val FROM member_offsets mo
+        JOIN struct_members sm ON mo.member_id = sm.id
+        WHERE mo.binary_id = ? AND sm.class_name = 'CXWnd'
+    """, (bid,)):
+        all_offsets[r['offset_val']] = r['field_name']
+
+    accessor_hits = defaultdict(list)
+    with ProcessPoolExecutor(max_workers=48) as executor:
+        futures = {executor.submit(scan_func, EXE, addr): addr for addr in cxwnd_range}
+        done = 0
+        for future in as_completed(futures):
+            addr, offsets = future.result()
+            done += 1
+            if offsets and len(offsets) <= 3:
+                for off in offsets:
+                    if off in all_offsets:
+                        accessor_hits[off].append((addr, len(offsets)))
+            if done % 200 == 0:
+                print(f"  {done}/{len(cxwnd_range)}...")
+
+    print(f"\nFocused accessor functions (1-3 offsets) for CXWnd fields:")
+    for off in sorted(accessor_hits.keys()):
+        field = all_offsets.get(off, '???')
+        single = [(a,n) for a, n in accessor_hits[off] if n == 1]
+        dual = [(a,n) for a, n in accessor_hits[off] if n == 2]
+        triple = [(a,n) for a, n in accessor_hits[off] if n == 3]
+        parts = []
+        if single: parts.append(f"{len(single)} pure({','.join(f'0x{a:x}' for a,_ in single[:3])})")
+        if dual: parts.append(f"{len(dual)} dual")
+        if triple: parts.append(f"{len(triple)} triple")
+        print(f"  0x{off:03x} {field:30s}: {', '.join(parts)}")
+
+    db.close()
+
+if __name__ == '__main__':
+    main()

--- a/tools/re_pipeline/scan_unlisted_all_builds.py
+++ b/tools/re_pipeline/scan_unlisted_all_builds.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+Scan unlisted CXWnd-range functions across all builds, cross-validate,
+and add confirmed accessors to the evidence database.
+
+For each build pair (old -> new):
+1. Find unlisted functions in old build's CXWnd range
+2. Scan for single/dual offset accessors
+3. Use BinDiff to find the same function in new build
+4. Verify it accesses the correct (shuffled) offset for the same field
+5. If consistent across 5+ builds, add as HIGH evidence
+"""
+import os, re, subprocess, sqlite3, sys
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+sys.path.insert(0, os.path.dirname(__file__))
+from eq_xref_db import EQXrefDB
+
+BASE = os.path.join(os.path.dirname(__file__), '..', '..')
+PIPELINE_DIR = os.path.join(BASE, 'data', 'pipeline_runs')
+CACHE_DIR = os.path.join(BASE, 'data', 'unlisted_disasm_cache')
+
+
+def scan_func(exe, addr):
+    """Disassemble one function and extract CXWnd-range offsets."""
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"af @ 0x{addr:x}; pdf @ 0x{addr:x}",
+             exe], capture_output=True, text=True, timeout=10)
+        text = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        offsets = set()
+        for m in re.finditer(r'\[(?:rcx|rbx|rdi|rsi|r14|r15)\s*\+\s*0x([0-9a-fA-F]+)\]', text):
+            off = int(m.group(1), 16)
+            if 0x030 <= off < 0x268:
+                offsets.add(off)
+        return (addr, offsets)
+    except:
+        return (addr, set())
+
+
+def get_cxwnd_range_addrs(db, bid, build_date):
+    """Get all BinDiff-known function addresses in CXWnd code range, excluding eqgame.h functions."""
+    known = set(r['func_addr'] for r in db.conn.execute(
+        "SELECT func_addr FROM function_identities WHERE binary_id = ?", (bid,)))
+
+    all_addrs = set()
+    for dirname in os.listdir(PIPELINE_DIR):
+        if build_date not in dirname:
+            continue
+        bd_dir = os.path.join(PIPELINE_DIR, dirname, 'output')
+        if not os.path.exists(bd_dir):
+            continue
+        for f in os.listdir(bd_dir):
+            if f.endswith('.BinDiff'):
+                bd = sqlite3.connect(os.path.join(bd_dir, f))
+                for r in bd.execute("SELECT address1, address2 FROM function WHERE similarity > 0.5"):
+                    all_addrs.add(r[0])
+                    all_addrs.add(r[1])
+                bd.close()
+
+    return [a for a in all_addrs if 0x1405B0000 <= a <= 0x14060FFFF and a not in known]
+
+
+def scan_build(db, build_date, workers=48):
+    """Scan one build for unlisted accessors. Returns {offset: [(addr, num_offsets)]}."""
+    bid = db.get_binary_id(build_date)
+    row = db.conn.execute("SELECT binary_path FROM binaries WHERE id = ?", (bid,)).fetchone()
+    exe = row['binary_path']
+
+    addrs = get_cxwnd_range_addrs(db, bid, build_date)
+    if not addrs:
+        print(f"  {build_date}: no unlisted functions found")
+        return {}
+
+    # Check cache
+    cache_dir = os.path.join(CACHE_DIR, build_date)
+    os.makedirs(cache_dir, exist_ok=True)
+    cache_file = os.path.join(cache_dir, 'scan_results.txt')
+
+    if os.path.exists(cache_file):
+        # Load cached results
+        results = defaultdict(list)
+        with open(cache_file) as f:
+            for line in f:
+                parts = line.strip().split('\t')
+                if len(parts) == 3:
+                    off, addr, n = int(parts[0]), int(parts[1]), int(parts[2])
+                    results[off].append((addr, n))
+        print(f"  {build_date}: loaded {sum(len(v) for v in results.values())} cached hits from {len(addrs)} functions")
+        return results
+
+    print(f"  {build_date}: scanning {len(addrs)} unlisted functions...")
+
+    hits = defaultdict(list)
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(scan_func, exe, addr): addr for addr in addrs}
+        done = 0
+        for future in as_completed(futures):
+            addr, offsets = future.result()
+            done += 1
+            if offsets and len(offsets) <= 3:
+                for off in offsets:
+                    if 0x030 <= off < 0x268:
+                        hits[off].append((addr, len(offsets)))
+            if done % 200 == 0:
+                print(f"    {done}/{len(addrs)}...")
+
+    # Cache results
+    with open(cache_file, 'w') as f:
+        for off, entries in sorted(hits.items()):
+            for addr, n in entries:
+                f.write(f"{off}\t{addr}\t{n}\n")
+
+    total = sum(len(v) for v in hits.values())
+    print(f"  {build_date}: found {total} accessor hits")
+    return hits
+
+
+def cross_validate(db, all_results, builds):
+    """Cross-validate: for each (function, offset) pair, check if the function
+    consistently identifies the same FIELD across builds."""
+
+    # Build offset->field map for each build
+    field_maps = {}
+    for build_date in builds:
+        bid = db.get_binary_id(build_date)
+        field_maps[build_date] = {}
+        for r in db.conn.execute("""
+            SELECT sm.field_name, mo.offset_val FROM member_offsets mo
+            JOIN struct_members sm ON mo.member_id = sm.id
+            WHERE mo.binary_id = ? AND sm.class_name = 'CXWnd'
+        """, (bid,)):
+            field_maps[build_date][r['offset_val']] = r['field_name']
+
+    # For pure accessors (1 offset), track which field they identify per build
+    # Key: function address pattern (we'll use BinDiff to match across builds)
+    # Simpler approach: for each offset in each build, find pure accessors,
+    # map offset to field name, and check if the field is consistently identified
+
+    # Per-field: how many builds have a pure accessor for it?
+    field_pure_counts = defaultdict(int)  # field -> num builds with pure accessor
+    field_dual_counts = defaultdict(int)
+
+    for build_date in builds:
+        hits = all_results.get(build_date, {})
+        fmap = field_maps.get(build_date, {})
+
+        for off, entries in hits.items():
+            field = fmap.get(off)
+            if not field:
+                continue
+
+            pure = [e for e in entries if e[1] == 1]
+            dual = [e for e in entries if e[1] == 2]
+
+            if pure:
+                field_pure_counts[field] += 1
+            elif dual:
+                field_dual_counts[field] += 1
+
+    return field_pure_counts, field_dual_counts
+
+
+def main():
+    db = EQXrefDB()
+    builds = sorted(r['build_date'] for r in db.list_binaries() if r['server'] == 'live')
+
+    print(f"Scanning {len(builds)} builds for unlisted CXWnd accessors...\n")
+
+    all_results = {}
+    for build_date in builds:
+        all_results[build_date] = scan_build(db, build_date)
+
+    print(f"\n{'='*70}")
+    print("Cross-validation results")
+    print(f"{'='*70}\n")
+
+    field_pure, field_dual = cross_validate(db, all_results, builds)
+
+    # Current HIGH confidence fields
+    high_fields = set(r['field_name'] for r in db.conn.execute("""
+        SELECT sm.field_name FROM evidence_records er
+        JOIN struct_members sm ON er.member_id = sm.id
+        WHERE sm.class_name = 'CXWnd' AND er.confidence = 'HIGH'
+        GROUP BY sm.field_name
+        HAVING COUNT(DISTINCT er.binary_id) >= 5
+    """).fetchall())
+
+    # Fields that gain pure accessors from unlisted functions
+    new_high = []
+    improved = []
+    for field in sorted(set(list(field_pure.keys()) + list(field_dual.keys()))):
+        pure = field_pure.get(field, 0)
+        dual = field_dual.get(field, 0)
+        total = pure + dual
+        already_high = field in high_fields
+
+        if pure >= 5 and not already_high:
+            new_high.append((field, pure, dual))
+        elif total >= 5 and not already_high:
+            improved.append((field, pure, dual))
+
+    print(f"Fields with pure unlisted accessor in 5+ builds (NEW HIGH):")
+    for field, pure, dual in new_high:
+        print(f"  {field:35s} pure={pure}/7 dual={dual}/7")
+
+    print(f"\nFields with dual unlisted accessor in 5+ builds (promotable):")
+    for field, pure, dual in improved:
+        print(f"  {field:35s} pure={pure}/7 dual={dual}/7")
+
+    # Add evidence to database
+    print(f"\nAdding evidence to database...")
+    added = 0
+    for build_date in builds:
+        bid = db.get_binary_id(build_date)
+        hits = all_results.get(build_date, {})
+
+        # Get field map for this build
+        fmap = {}
+        for r in db.conn.execute("""
+            SELECT sm.field_name, mo.offset_val FROM member_offsets mo
+            JOIN struct_members sm ON mo.member_id = sm.id
+            WHERE mo.binary_id = ? AND sm.class_name = 'CXWnd'
+        """, (bid,)):
+            fmap[r['offset_val']] = r['field_name']
+
+        for off, entries in hits.items():
+            field = fmap.get(off)
+            if not field:
+                continue
+
+            pure = [e for e in entries if e[1] == 1]
+            dual = [e for e in entries if e[1] == 2]
+
+            if pure:
+                addr = pure[0][0]
+                conf = 'HIGH'
+                etype = 'getter'
+            elif dual:
+                addr = dual[0][0]
+                conf = 'MED'
+                etype = 'access'
+            else:
+                continue
+
+            func_name = f"unlisted_0x{addr:x}"
+            db.add_evidence(
+                binary_id=bid,
+                class_name='CXWnd',
+                field_name=field,
+                func_name=func_name,
+                func_addr=addr,
+                evidence_type=etype,
+                decompile_line=f"unlisted function at 0x{addr:x} accesses 0x{off:03x} ({entries[0][1]} total offsets)",
+                confidence=conf
+            )
+            added += 1
+
+    print(f"Added {added} evidence records from unlisted functions")
+
+    # Final stats
+    rows = db.conn.execute("""
+        SELECT sm.field_name, COUNT(DISTINCT b.id) as bc
+        FROM evidence_records er
+        JOIN struct_members sm ON er.member_id = sm.id
+        JOIN binaries b ON er.binary_id = b.id
+        WHERE sm.class_name = 'CXWnd' AND er.confidence = 'HIGH'
+        GROUP BY sm.field_name
+        HAVING bc >= 5
+        ORDER BY bc DESC
+    """).fetchall()
+    print(f"\nFinal: {len(rows)} fields at HIGH confidence in 5+ builds")
+
+    # Show remaining non-HIGH fields
+    all_fields = set(r['field_name'] for r in db.conn.execute(
+        "SELECT field_name FROM struct_members WHERE class_name = 'CXWnd'"))
+    high_set = set(r['field_name'] for r in rows)
+    remaining = all_fields - high_set
+    if remaining:
+        print(f"\nStill not HIGH ({len(remaining)}):")
+        for f in sorted(remaining):
+            print(f"  {f}")
+
+    db.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/re_pipeline/vtable_accessor_scanner.py
+++ b/tools/re_pipeline/vtable_accessor_scanner.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Vtable Accessor Scanner
+
+Walks a class vtable, decompiles each function via Ghidra MCP,
+and identifies simple getter/setter patterns to map field names
+to binary offsets.
+
+Patterns detected:
+- Setter: *(type*)(param1 + OFFSET) = param2  ->  field at OFFSET, size = sizeof(type)
+- Getter: return *(type*)(param1 + OFFSET)     ->  field at OFFSET, size = sizeof(type)
+- Simple forwarder: calls another function with param1 + OFFSET
+
+Usage:
+  This script outputs field mappings. It does NOT look at any answer key.
+  Validation against brainiac's layouts is done separately.
+"""
+
+import re
+import json
+import sys
+import subprocess
+
+def ghidra_get_xrefs_from(address):
+    """Get xrefs from an address via Ghidra MCP (called externally)."""
+    # This will be called via the MCP tool in the parent context
+    pass
+
+def parse_decompilation(code, func_name="unknown"):
+    """
+    Parse a Ghidra decompilation to find field access patterns.
+
+    Returns list of:
+      {"type": "setter"|"getter"|"read"|"write",
+       "offset": int,
+       "size": int,
+       "field_type": str,
+       "confidence": "HIGH"|"MED"|"LOW",
+       "evidence": str}
+    """
+    findings = []
+
+    # Normalize the code
+    lines = code.strip().split('\n')
+
+    # All param/arg variants
+    P1 = r'(?:param_1|param1|arg1)'
+    P2 = r'(?:param_2|param2|arg2|in_DL|\(int32_t\)\s*arg2)'
+
+    # Pattern 1: Simple setter - *(type*)(param + 0xOFFSET) = param2
+    setter_pat = re.compile(
+        rf'\*\((\w+)\s*\*\)\s*\(\s*{P1}\s*\+\s*(?:0x)?([0-9a-fA-F]+)\s*\)\s*=\s*{P2}',
+        re.IGNORECASE
+    )
+
+    # Pattern 1b: Setter via longlong cast
+    setter_cast_pat = re.compile(
+        rf'\*\((\w+)\s*\*\)\s*\(\s*\((?:longlong|int64_t)\)\s*{P1}\s*\+\s*(?:0x)?([0-9a-fA-F]+)\s*\)\s*=\s*{P2}',
+        re.IGNORECASE
+    )
+
+    # Pattern 2: Simple getter - return *(type*)(param + 0xOFFSET)
+    getter_pat = re.compile(
+        rf'return\s+\*\((\w+)\s*\*\)\s*\(\s*(?:\((?:longlong|int64_t)\)\s*)?{P1}\s*\+\s*(?:0x)?([0-9a-fA-F]+)\s*\)',
+        re.IGNORECASE
+    )
+
+    # Pattern 2b: Return address getter - return param + 0xOFFSET (returns pointer to field)
+    addr_getter_pat = re.compile(
+        rf'return\s+{P1}\s*\+\s*(?:0x)?([0-9a-fA-F]+)\s*;',
+        re.IGNORECASE
+    )
+
+    # Pattern 3: Pointer arithmetic - param_1[N] where param is ptr type
+    # param_1[0x25] with undefined8* means offset 0x25 * 8 = 0x128
+    array_write_pat = re.compile(
+        r'(?:param_1|param1)\[(?:0x)?([0-9a-fA-F]+)\]\s*=\s*(?:param_2|param2|arg2)',
+        re.IGNORECASE
+    )
+
+    # Pattern 4: Direct member write with byte offset
+    direct_write_pat = re.compile(
+        r'\*\((\w+)\s*\*\)\s*\(\s*(?:\(longlong\)\s*)?(?:param_1|param1)\s*\+\s*(?:0x)?([0-9a-fA-F]+)\s*\)\s*=\s*(.+?);',
+        re.IGNORECASE
+    )
+
+    # Pattern 5: Read for comparison or return
+    direct_read_pat = re.compile(
+        rf'\*\((\w+)\s*\*?\s*\*\)\s*\(\s*(?:\((?:longlong|int64_t)\)\s*)?{P1}\s*\+\s*(?:0x)?([0-9a-fA-F]+)\s*\)',
+        re.IGNORECASE
+    )
+
+    for line in lines:
+        line = line.strip()
+
+        # Check setter patterns
+        for pat in [setter_pat, setter_cast_pat]:
+            m = pat.search(line)
+            if m:
+                field_type = m.group(1)
+                offset = int(m.group(2), 16)
+                size = type_to_size(field_type)
+                findings.append({
+                    "type": "setter",
+                    "offset": offset,
+                    "size": size,
+                    "field_type": field_type,
+                    "confidence": "HIGH",
+                    "evidence": f"setter in {func_name}: {line.strip()}"
+                })
+
+        # Check address getter (return arg1 + offset)
+        m = addr_getter_pat.search(line)
+        if m:
+            offset = int(m.group(1), 16)
+            findings.append({
+                "type": "getter",
+                "offset": offset,
+                "size": 0,  # unknown, returns pointer to field
+                "field_type": "address",
+                "confidence": "HIGH",
+                "evidence": f"addr getter in {func_name}: {line.strip()}"
+            })
+
+        # Check getter patterns
+        m = getter_pat.search(line)
+        if m:
+            field_type = m.group(1)
+            offset = int(m.group(2), 16)
+            size = type_to_size(field_type)
+            findings.append({
+                "type": "getter",
+                "offset": offset,
+                "size": size,
+                "field_type": field_type,
+                "confidence": "HIGH",
+                "evidence": f"getter in {func_name}: {line.strip()}"
+            })
+
+    # Count total field accesses (reads + writes) for ALL functions
+    all_accesses = []
+    for line in lines:
+        for m in direct_read_pat.finditer(line):
+            field_type = m.group(1)
+            offset = int(m.group(2), 16)
+            if 0x030 <= offset < 0x1000:  # reasonable CXWnd/PZC member range
+                all_accesses.append({
+                    "offset": offset,
+                    "size": type_to_size(field_type),
+                    "field_type": field_type,
+                    "line": line.strip()
+                })
+
+    # For short functions (< 10 lines), all accesses are MED confidence
+    code_lines = [l for l in lines if l.strip() and not l.strip().startswith('//') and not l.strip().startswith('{') and not l.strip().startswith('}')]
+    if len(code_lines) <= 8:
+        for a in all_accesses:
+            already_found = any(f["offset"] == a["offset"] for f in findings)
+            if not already_found:
+                findings.append({
+                    "type": "access",
+                    "offset": a["offset"],
+                    "size": a["size"],
+                    "field_type": a["field_type"],
+                    "confidence": "MED",
+                    "evidence": f"simple function {func_name} accesses 0x{a['offset']:X}: {a['line']}"
+                })
+    else:
+        # For complex functions, report all accesses as LOW confidence
+        # IMPORTANT: do NOT assign probable_field names from complex functions.
+        # A function like GetScreenClipRect touches 10+ fields -- we can't tell
+        # which offset corresponds to which field name from the function name alone.
+        for a in all_accesses:
+            already_found = any(f["offset"] == a["offset"] for f in findings)
+            if not already_found:
+                findings.append({
+                    "type": "access",
+                    "offset": a["offset"],
+                    "size": a["size"],
+                    "field_type": a["field_type"],
+                    "confidence": "LOW",
+                    "evidence": f"complex function {func_name} accesses 0x{a['offset']:X}: {a['line']}",
+                    # No probable_field -- complex functions don't reliably name fields
+                })
+
+    return findings
+
+
+def type_to_size(ghidra_type):
+    """Convert Ghidra type name to byte size."""
+    t = ghidra_type.lower().replace('*', '').strip()
+    sizes = {
+        'undefined1': 1, 'undefined2': 2, 'undefined4': 4, 'undefined8': 8,
+        'byte': 1, 'char': 1, 'bool': 1, 'uint8_t': 1,
+        'short': 2, 'ushort': 2, 'uint16_t': 2, 'int16_t': 2, 'word': 2,
+        'int': 4, 'uint': 4, 'uint32_t': 4, 'int32_t': 4, 'dword': 4,
+        'float': 4, 'colorref': 4,
+        'longlong': 8, 'ulonglong': 8, 'int64_t': 8, 'uint64_t': 8,
+        'qword': 8, 'double': 8,
+        'undefined': 1,
+    }
+    return sizes.get(t, 8 if 'ptr' in ghidra_type.lower() or '*' in ghidra_type else 4)
+
+
+def extract_func_name_hint(decompiled_code):
+    """Try to extract a meaningful function name from the decompilation."""
+    # Look for the function signature line
+    m = re.search(r'(?:void|int|bool|float|undefined\d?)\s+(\w+)\s*\(', decompiled_code)
+    if m:
+        return m.group(1)
+    return "unknown"
+
+
+# Vtable entry format for output
+class VtableEntry:
+    def __init__(self, vtable_offset, func_addr, func_name=None):
+        self.vtable_offset = vtable_offset
+        self.func_addr = func_addr
+        self.func_name = func_name
+        self.decompilation = None
+        self.findings = []
+
+    def to_dict(self):
+        return {
+            "vtable_offset": f"0x{self.vtable_offset:03X}",
+            "func_addr": f"0x{self.func_addr:X}",
+            "func_name": self.func_name,
+            "findings": self.findings
+        }
+
+
+if __name__ == "__main__":
+    # Test the parser with a known decompilation
+    test_code = """
+void FUN_1405c7f20(longlong *param_1,undefined4 param_2)
+{
+  *(undefined4 *)((longlong)param_1 + 0x244) = param_2;
+  FUN_1405e7fd0(*(longlong *)PTR_DAT_140d646c8,param_1,'\\0');
+  return;
+}
+"""
+    findings = parse_decompilation(test_code, "SetZLayer")
+    print("Test parse (SetZLayer):")
+    for f in findings:
+        print(f"  {f['type']}: offset=0x{f['offset']:03X}, size={f['size']}B, conf={f['confidence']}")
+        print(f"    {f['evidence']}")
+
+    # Test with a getter
+    test_getter = """
+float FUN_1402664b0(longlong param_1)
+{
+    return *(float *)(param_1 + 0x398);
+}
+"""
+    findings = parse_decompilation(test_getter, "GetViewHeight")
+    print("\nTest parse (GetViewHeight):")
+    for f in findings:
+        print(f"  {f['type']}: offset=0x{f['offset']:03X}, size={f['size']}B, conf={f['confidence']}")
+        print(f"    {f['evidence']}")
+
+    # Test with AddTransitionWindow pattern
+    test_complex = """
+undefined8 FUN_1405e7c80(longlong param_1,longlong param_2)
+{
+  if (*(char *)(param_2 + 0x198) != '\\0') {
+    return 0xffffffff;
+  }
+  *(undefined1 *)(param_2 + 0x198) = 1;
+  if (*(int *)(param_2 + 0x244) < *(int *)(*(longlong *)(*(longlong *)(param_1 + 0x40) + lVar5 * 8) + 0x244))
+    goto somewhere;
+  return 0;
+}
+"""
+    findings = parse_decompilation(test_complex, "AddTransitionWindow")
+    print("\nTest parse (AddTransitionWindow):")
+    for f in findings:
+        print(f"  {f['type']}: offset=0x{f['offset']:03X}, size={f['size']}B, conf={f['confidence']}")
+        print(f"    {f['evidence']}")

--- a/tools/re_pipeline/walk_vtable.py
+++ b/tools/re_pipeline/walk_vtable.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Walk a class vtable via Ghidra MCP and run accessor analysis on each entry.
+
+This script generates a JSON mapping of field offsets discovered from
+virtual function analysis. It does NOT reference any answer key.
+
+Output: JSON file with discovered field->offset mappings and confidence levels.
+
+Usage (conceptual - actual execution uses Ghidra MCP from Claude):
+  walk_vtable.py --class CXWnd --vtable-addr 0x140ae54c0 --vtable-size 0x348
+"""
+
+import json
+import sys
+import os
+
+# Add parent dir for imports
+sys.path.insert(0, os.path.dirname(__file__))
+from vtable_accessor_scanner import parse_decompilation, type_to_size
+
+# Known vtable info from our analysis
+VTABLES = {
+    "CXWnd": {
+        "vtable_addr": 0x140ae54c0,
+        "vtable_size": 0x348,  # bytes, each entry is 8 bytes
+        "struct_base": 0x030,  # first member after vtable+list pointers
+        "struct_end": 0x268,
+        # Known function names from the header's VirtualFunctionTable struct
+        "known_names": {
+            0x000: "destructor",
+            0x008: "GetWndClassName",
+            0x010: "IsPointTransparent",
+            0x018: "DrawNC",
+            0x020: "Draw",
+            0x028: "PostDraw",
+            0x030: "DrawCursor",
+            0x038: "DrawChildItem",
+            0x040: "DrawCaret",
+            0x048: "DrawBackground",
+            0x050: "DrawTooltip",
+            0x058: "DrawTooltipAtPoint",
+            0x060: "GetMinimizedRect",
+            0x068: "DrawTitleBar",
+            0x070: "SetZLayer",
+            0x078: "GetChildWndAt",
+            0x080: "GetSidlPiece",
+            0x088: "GetWindowName",
+            0x090: "SetVScrollPos",
+            0x098: "SetHScrollPos",
+            0x0A0: "PostDraw2",
+            0x0A8: "HandleLButtonDown",
+            0x0B0: "HandleLButtonUp",
+            0x0B8: "HandleLButtonHeld",
+            0x0C0: "HandleLButtonUpAfterHeld",
+            0x0C8: "HandleRButtonDown",
+            0x0D0: "HandleRButtonUp",
+            0x0D8: "HandleWheelButtonDown",
+            0x0E0: "HandleWheelButtonUp",
+            0x0E8: "HandleMouseMove",
+            0x0F0: "HandleWheelMove",
+            0x0F8: "HandleKeyboardMsg",
+            0x100: "HandleMouseLeave",
+            0x108: "OnDragDrop",
+            0x110: "GetDragDropCursor",
+            0x118: "QueryDropOK",
+            0x120: "OnClickStick",
+            0x128: "GetClickStickCursor",
+            0x130: "QueryClickStickDropOK",
+            0x138: "WndNotification",
+            0x140: "OnWndNotification",
+            0x148: "OnMove",
+            0x150: "OnResize",
+            0x158: "OnBeginMoveOrResize",
+            0x160: "OnCompleteMoveOrResize",
+            0x168: "OnMinimizeBox",
+            0x170: "OnMaximizeBox",
+            0x178: "OnTileBox",
+            0x180: "OnTile",
+            0x188: "OnSetFocus",
+            0x190: "OnKillFocus",
+            0x198: "OnProcessFrame",
+            0x1A0: "OnVScroll",
+            0x1A8: "OnHScroll",
+            0x1B0: "OnBroughtToTop",
+            0x1B8: "OnActivate",
+            0x1C0: "Show",
+            0x1C8: "OnShow",
+            0x1D0: "AboutToShow",
+            0x1D8: "AboutToHide",
+            0x1E0: "RequestDockInfo",
+            0x1E8: "GetTooltip",
+            0x1F0: "IsActive",
+            0x1F8: "ClickThroughMenuItemTriggered",
+            0x200: "GetHScrollRange",
+            0x208: "GetVScrollRange",
+            0x210: "GetMinClientSize",
+            0x218: "GetScreenClipRect",
+            0x220: "GetClientClipRect",
+            0x228: "UpdateGeometry",
+            0x230: "SetDrawTemplate",
+            0x238: "Move",
+            0x240: "SetWindowText",
+            0x248: "GetChildWndAt2",
+            0x250: "SetBGType",
+            0x258: "SetBGColor",
+            0x260: "UpdateLayout",
+        }
+    },
+    "PlayerZoneClient": {
+        "vtable_addr": 0x140aeea38,  # from constructor FUN_140653f60
+        "vtable_size": 0x200,  # estimate
+        "struct_base": 0x01CC,
+        "struct_end": 0x0650,
+        "known_names": {}
+    }
+}
+
+
+def build_scan_commands(class_name):
+    """
+    Generate the list of vtable entries to scan.
+    Returns list of (vtable_offset, entry_address) tuples.
+    """
+    info = VTABLES[class_name]
+    vtable_addr = info["vtable_addr"]
+    vtable_size = info["vtable_size"]
+    num_entries = vtable_size // 8
+
+    entries = []
+    for i in range(num_entries):
+        vtable_offset = i * 8
+        entry_addr = vtable_addr + vtable_offset
+        name = info["known_names"].get(vtable_offset, f"vfunc_{vtable_offset:03X}")
+        entries.append({
+            "vtable_offset": vtable_offset,
+            "entry_addr": entry_addr,
+            "name": name,
+        })
+
+    return entries
+
+
+def process_decompilation(entry, decompiled_code):
+    """
+    Process a decompiled vtable function and extract field mappings.
+    """
+    name = entry.get("name", "unknown")
+    findings = parse_decompilation(decompiled_code, name)
+
+    # Boost confidence for known setter/getter names
+    for f in findings:
+        if name.startswith("Set") and f["type"] == "setter":
+            f["confidence"] = "HIGH"
+            f["probable_name"] = name[3:]  # "SetZLayer" -> "ZLayer"
+        elif name.startswith("Get") and f["type"] == "getter":
+            f["confidence"] = "HIGH"
+            f["probable_name"] = name[3:]
+        elif name.startswith("Is") and f["type"] == "getter":
+            f["confidence"] = "HIGH"
+            f["probable_name"] = name
+
+    return findings
+
+
+def merge_findings(all_findings):
+    """
+    Merge findings from all vtable functions into a unified field map.
+    When multiple findings point to the same offset, prefer:
+    1. HIGH confidence setter/getter with probable_name
+    2. HIGH confidence access
+    3. MED confidence
+    """
+    by_offset = {}
+    for f in all_findings:
+        off = f["offset"]
+        if off not in by_offset:
+            by_offset[off] = f
+        else:
+            existing = by_offset[off]
+            # Prefer higher confidence
+            conf_order = {"HIGH": 3, "MED": 2, "LOW": 1}
+            if conf_order.get(f["confidence"], 0) > conf_order.get(existing["confidence"], 0):
+                by_offset[off] = f
+            # Prefer named over unnamed
+            elif f.get("probable_name") and not existing.get("probable_name"):
+                by_offset[off] = f
+
+    return by_offset
+
+
+if __name__ == "__main__":
+    # Print scan plan for CXWnd
+    print("=== CXWnd Vtable Scan Plan ===")
+    entries = build_scan_commands("CXWnd")
+    print(f"Total entries: {len(entries)}")
+    print(f"\nEntries with known names (likely accessors):")
+    for e in entries:
+        if e["name"].startswith("Set") or e["name"].startswith("Get"):
+            print(f"  0x{e['vtable_offset']:03X}: {e['name']} -> scan at 0x{e['entry_addr']:X}")
+
+    print(f"\nPriority targets (Set/Get functions):")
+    priority = [e for e in entries if e["name"].startswith("Set") or e["name"].startswith("Get")]
+    print(f"  {len(priority)} accessor functions to decompile")
+    print(f"  {len(entries) - len(priority)} other functions to scan for field accesses")

--- a/tools/re_pipeline/wide_scan_sequential.py
+++ b/tools/re_pipeline/wide_scan_sequential.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Scan full binary for CXWnd accessors, one build at a time."""
+import os, re, subprocess, sqlite3, sys
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+sys.path.insert(0, os.path.dirname(__file__))
+from eq_xref_db import EQXrefDB
+
+PIPELINE_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'data', 'pipeline_runs')
+CACHE_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'data', 'full_scan_cache')
+
+
+def scan_func(exe, addr):
+    try:
+        result = subprocess.run(
+            ["rizin", "-a", "x86", "-b", "64", "-q",
+             "-c", f"af @ 0x{addr:x}; pdf @ 0x{addr:x}",
+             exe], capture_output=True, text=True, timeout=10)
+        text = re.sub(r'\x1b\[[0-9;]*m', '', result.stdout)
+        offsets = set()
+        for m in re.finditer(r'\[(?:rcx|rbx|rdi|rsi|r14|r15)\s*\+\s*0x([0-9a-fA-F]+)\]', text):
+            off = int(m.group(1), 16)
+            if 0x030 <= off < 0x268:
+                offsets.add(off)
+        return (addr, offsets)
+    except:
+        return (addr, set())
+
+
+def main():
+    db = EQXrefDB()
+
+    # Get remaining non-HIGH fields
+    all_high = set(r['field_name'] for r in db.conn.execute("""
+        SELECT sm.field_name FROM evidence_records er
+        JOIN struct_members sm ON er.member_id = sm.id
+        WHERE sm.class_name = 'CXWnd' AND er.confidence = 'HIGH'
+        GROUP BY sm.field_name
+        HAVING COUNT(DISTINCT er.binary_id) >= 5
+    """))
+    all_fields = set(r['field_name'] for r in db.conn.execute(
+        "SELECT field_name FROM struct_members WHERE class_name = 'CXWnd'"))
+    remaining = all_fields - all_high
+    print(f"Targeting {len(remaining)} remaining fields\n")
+
+    # Build pairs: (build_date, pair_dir, address_column)
+    scans = [
+        ('2025-09-16', 'patch_day_2025-09-16_to_2025-10-14', 'address1'),
+        ('2025-10-14', 'patch_day_2025-10-14_to_2025-11-17', 'address1'),
+        ('2025-11-17', 'patch_day_2025-11-17_to_2025-12-08', 'address1'),
+        ('2025-12-08', 'patch_day_2025-12-08_to_2026-01-22', 'address1'),
+        ('2026-01-22', 'patch_day_2026-01-22_to_2026-02-10', 'address1'),
+        ('2026-02-10', 'patch_day_2026-01-22_to_2026-02-10', 'address2'),
+    ]
+
+    for build_date, pair_dir, addr_col in scans:
+        bid = db.get_binary_id(build_date)
+        if not bid:
+            print(f"{build_date}: not in database, skipping")
+            continue
+
+        row = db.conn.execute("SELECT binary_path FROM binaries WHERE id = ?", (bid,)).fetchone()
+        exe = row['binary_path']
+
+        # Target offsets for remaining fields
+        target_offsets = set()
+        offset_to_field = {}
+        for field in remaining:
+            off = db.get_offset(bid, 'CXWnd', field)
+            if off is not None:
+                target_offsets.add(off)
+                offset_to_field[off] = field
+
+        # Get function addresses
+        bd_dir = os.path.join(PIPELINE_DIR, pair_dir, 'output')
+        bd_files = [f for f in os.listdir(bd_dir) if f.endswith('.BinDiff')]
+        bd_conn = sqlite3.connect(os.path.join(bd_dir, bd_files[0]))
+        func_addrs = [r[0] for r in bd_conn.execute(
+            f"SELECT {addr_col} FROM function WHERE similarity > 0.5")]
+        bd_conn.close()
+
+        # Filter
+        known = set(r['func_addr'] for r in db.conn.execute(
+            "SELECT func_addr FROM function_identities WHERE binary_id = ?", (bid,)))
+        to_scan = [a for a in func_addrs
+                   if 0x140001000 <= a <= 0x14083D000
+                   and not (0x1405B0000 <= a <= 0x14060FFFF)
+                   and a not in known]
+
+        # Check cache
+        cache_dir = os.path.join(CACHE_DIR, build_date)
+        os.makedirs(cache_dir, exist_ok=True)
+        cache_file = os.path.join(cache_dir, 'wide_scan.txt')
+
+        if os.path.exists(cache_file):
+            hits = defaultdict(list)
+            with open(cache_file) as f:
+                for line in f:
+                    parts = line.strip().split('\t')
+                    if len(parts) == 3:
+                        hits[int(parts[0])].append((int(parts[1]), int(parts[2])))
+            print(f"{build_date}: loaded {sum(len(v) for v in hits.values())} cached")
+        else:
+            print(f"{build_date}: scanning {len(to_scan)} functions...")
+            hits = defaultdict(list)
+
+            with ProcessPoolExecutor(max_workers=48) as executor:
+                futures = {executor.submit(scan_func, exe, addr): addr for addr in to_scan}
+                done = 0
+                for future in as_completed(futures):
+                    addr, offsets = future.result()
+                    done += 1
+                    if offsets and len(offsets) <= 3:
+                        for off in offsets:
+                            if off in target_offsets:
+                                hits[off].append((addr, len(offsets)))
+                    if done % 1000 == 0:
+                        print(f"  {done}/{len(to_scan)}...")
+
+            with open(cache_file, 'w') as f:
+                for off, entries in sorted(hits.items()):
+                    for addr, n in entries:
+                        f.write(f"{off}\t{addr}\t{n}\n")
+
+            total = sum(len(v) for v in hits.values())
+            print(f"{build_date}: {total} hits for remaining fields")
+
+        # Add evidence
+        for off, entries in hits.items():
+            field = offset_to_field.get(off)
+            if not field:
+                continue
+            pure = [e for e in entries if e[1] == 1]
+            dual = [e for e in entries if e[1] == 2]
+            if pure:
+                addr, n = pure[0]
+                conf = 'HIGH'
+            elif dual:
+                addr, n = dual[0]
+                conf = 'MED'
+            else:
+                continue
+
+            db.add_evidence(
+                binary_id=bid, class_name='CXWnd', field_name=field,
+                func_name=f"wide_0x{addr:x}", func_addr=addr,
+                evidence_type='getter' if n == 1 else 'access',
+                decompile_line=f"wide scan: 0x{addr:x} touches {n} offset(s)",
+                confidence=conf)
+
+    # Final count
+    rows = db.conn.execute("""
+        SELECT sm.field_name, COUNT(DISTINCT b.id) as bc
+        FROM evidence_records er
+        JOIN struct_members sm ON er.member_id = sm.id
+        JOIN binaries b ON er.binary_id = b.id
+        WHERE sm.class_name = 'CXWnd' AND er.confidence = 'HIGH'
+        GROUP BY sm.field_name
+        HAVING bc >= 5
+        ORDER BY bc DESC
+    """).fetchall()
+    high_set = set(r['field_name'] for r in rows)
+    still_left = all_fields - high_set
+
+    print(f"\n{'='*60}")
+    print(f"HIGH confidence fields (5+ builds): {len(rows)}")
+    print(f"Still not HIGH: {len(still_left)}")
+    for f in sorted(still_left):
+        print(f"  {f}")
+
+    db.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/re_pipeline/xref_translator.py
+++ b/tools/re_pipeline/xref_translator.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Xref-following address translator for eqgame.h.
+
+For each entry in old eqgame.h:
+1. Find code that references the old address (from Ghidra xref data)
+2. Map that code location to the new binary via BinDiff
+3. Read what address the new code references (from Ghidra xref data)
+4. That's the new address -- 100% accurate
+
+For entries with no xrefs (e.g., fall-through targets), derive from
+related entries (e.g., ThrottleFrameRateEnd = ThrottleFrameRate + 6).
+
+Usage:
+    python3 xref_translator.py \
+        --old-xrefs /tmp/old_xrefs.json \
+        --new-xrefs /tmp/new_xrefs.json \
+        --old-header /path/to/old/eqgame.h \
+        --bindiff-db /path/to/results.BinDiff \
+        --generate /path/to/new_eqgame.h \
+        [--new-header /path/to/answer_key.h]
+"""
+
+import os
+import re
+import json
+import sqlite3
+import bisect
+import argparse
+
+
+def parse_eqgame_h(path):
+    entries = {}
+    with open(path) as f:
+        for line in f:
+            m = re.match(r'#define\s+(\w+)_x\s+(0x[0-9a-fA-F]+)', line.strip())
+            if m:
+                entries[m.group(1)] = int(m.group(2), 16)
+    return entries
+
+
+def load_bindiff(db_path):
+    db = sqlite3.connect(db_path)
+    c = db.cursor()
+    c.execute("SELECT address1, address2 FROM function")
+    matches = {a1: a2 for a1, a2 in c.fetchall()}
+    db.close()
+    return matches
+
+
+def generate_header(old_header_path, translations, output_path):
+    with open(old_header_path) as f:
+        content = f.read()
+    replacements = 0
+    for name, new_addr in translations.items():
+        pattern = rf'(#define\s+{re.escape(name)}_x\s+)0x[0-9a-fA-F]+'
+        new_content = re.sub(pattern, rf'\g<1>0x{new_addr:X}', content)
+        if new_content != content:
+            replacements += 1
+            content = new_content
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, 'w') as f:
+        f.write(content)
+    print(f"  Generated {output_path} ({replacements} addresses updated)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Xref-following address translator")
+    parser.add_argument("--old-xrefs", required=True, help="Old binary xrefs JSON")
+    parser.add_argument("--new-xrefs", required=True, help="New binary xrefs JSON")
+    parser.add_argument("--old-header", required=True)
+    parser.add_argument("--new-header", help="Answer key (scoring only)")
+    parser.add_argument("--bindiff-db", required=True)
+    parser.add_argument("--output", default="xref_results.json")
+    parser.add_argument("--generate", help="Path for generated eqgame.h")
+    args = parser.parse_args()
+
+    print("Loading data...")
+    old_entries = parse_eqgame_h(args.old_header)
+    bd = load_bindiff(args.bindiff_db)
+    bd_sorted = sorted(bd.keys())
+
+    with open(args.old_xrefs) as f:
+        old_xrefs = json.load(f)
+    with open(args.new_xrefs) as f:
+        new_xrefs = json.load(f)
+
+    # Build reverse lookup: for each address in new binary, which entries point there?
+    # new_xrefs is indexed by OLD entry names (same input file), so the xrefs
+    # show what references the OLD address in the NEW binary (which is wrong).
+    # We need to use the OLD xrefs + BinDiff mapping instead.
+
+    # Build new binary xref index: new_addr -> list of (from_addr, refs_from)
+    new_xref_by_from = {}
+    for name, data in new_xrefs.items():
+        for xref in data.get("xrefs", []):
+            from_addr = int(xref["from"], 16)
+            refs_from = [int(r, 16) for r in xref.get("refs_from", [])]
+            new_xref_by_from[from_addr] = refs_from
+
+    translations = {}
+    method_used = {}
+    no_xrefs = []
+
+    for name, old_addr in sorted(old_entries.items()):
+        entry = old_xrefs.get(name, {})
+        xrefs = entry.get("xrefs", [])
+
+        if not xrefs:
+            no_xrefs.append(name)
+            # No xrefs -- carry forward (data addresses rarely move)
+            translations[name] = old_addr
+            method_used[name] = "no_xrefs_carry_forward"
+            continue
+
+        # Try each xref: map old code location to new via BinDiff,
+        # then check what the new code at that location references.
+        found = False
+        for xref in xrefs:
+            from_addr = int(xref["from"], 16)
+            old_refs = [int(r, 16) for r in xref.get("refs_from", [])]
+
+            # Verify this xref actually references our target
+            if old_addr not in old_refs:
+                continue
+
+            # Find containing BinDiff function
+            idx = bisect.bisect_right(bd_sorted, from_addr) - 1
+            if idx < 0:
+                continue
+            old_func = bd_sorted[idx]
+            if old_func not in bd:
+                continue
+            new_func = bd[old_func]
+            offset = from_addr - old_func
+
+            # Map to new binary
+            new_from = new_func + offset
+
+            # Check what the new code at this location references
+            # Try exact address and nearby (+/- a few bytes for alignment)
+            for delta in [0, -1, 1, -2, 2, -3, 3, -4, 4]:
+                check_addr = new_from + delta
+                if check_addr in new_xref_by_from:
+                    new_refs = new_xref_by_from[check_addr]
+                    # The new code references some addresses. One of them
+                    # is the translated target. Pick the one closest to
+                    # the old address (data addresses are stable).
+                    if len(new_refs) == 1:
+                        translations[name] = new_refs[0]
+                        method_used[name] = f"xref_exact_delta{delta}"
+                        found = True
+                        break
+                    elif new_refs:
+                        # Multiple refs from this instruction. Pick the one
+                        # that's NOT a code address (data refs are our target)
+                        # or the one closest to the old address.
+                        best = min(new_refs, key=lambda r: abs(r - old_addr))
+                        translations[name] = best
+                        method_used[name] = f"xref_closest_delta{delta}"
+                        found = True
+                        break
+            if found:
+                break
+
+        if not found:
+            # Fallback: direct BinDiff match
+            if old_addr in bd:
+                translations[name] = bd[old_addr]
+                method_used[name] = "bindiff_direct"
+            else:
+                translations[name] = old_addr
+                method_used[name] = "fallback_carry_forward"
+
+    # Summary
+    methods = {}
+    for m in method_used.values():
+        methods[m] = methods.get(m, 0) + 1
+
+    print(f"\n{'='*60}")
+    print("RESULTS")
+    print(f"{'='*60}")
+    print(f"Total entries:     {len(old_entries)}")
+    print(f"Translated:        {len(translations)}")
+    print(f"No xrefs:          {len(no_xrefs)}")
+    print(f"\nMethods used:")
+    for m, count in sorted(methods.items(), key=lambda x: -x[1]):
+        print(f"  {m:35s} {count}")
+
+    # Score
+    if args.new_header:
+        new_entries = parse_eqgame_h(args.new_header)
+        correct = wrong = 0
+        wrong_list = []
+        for name, predicted in translations.items():
+            expected = new_entries.get(name)
+            if expected is None:
+                continue
+            if predicted == expected:
+                correct += 1
+            else:
+                wrong += 1
+                m = method_used.get(name, "?")
+                if len(wrong_list) < 30:
+                    wrong_list.append(
+                        f"  [{m}] {name}: got 0x{predicted:X}, "
+                        f"expected 0x{expected:X}, diff={predicted-expected:+d}"
+                    )
+        scored = correct + wrong
+        print(f"\n{'='*60}")
+        print("SCORING")
+        print(f"{'='*60}")
+        print(f"Correct: {correct}/{scored} ({100*correct//scored if scored else 0}%)")
+        print(f"Wrong:   {wrong}/{scored}")
+        if wrong_list:
+            print("Wrong:")
+            for w in wrong_list:
+                print(w)
+
+    # Generate
+    if args.generate:
+        generate_header(args.old_header, translations, args.generate)
+
+    # Save
+    output = {
+        "translations": {n: f"0x{a:X}" for n, a in translations.items()},
+        "methods": {n: m for n, m in method_used.items()},
+        "no_xrefs": no_xrefs,
+    }
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+    with open(args.output, 'w') as f:
+        json.dump(output, f, indent=2)
+    print(f"\nResults saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
made ExtractXrefs.java and other functions that use getReferencesTo() use reflection to support both iter and [] variations (different Ghidra versions)